### PR TITLE
Make Auto Fight Bosses much more aggressive / less passive

### DIFF
--- a/NGUInjector/Main.cs
+++ b/NGUInjector/Main.cs
@@ -591,7 +591,7 @@ namespace NGUInjector
                         bc.startNuke();
                     else
                     {
-                        if (bc.character.attack > (bc.character.bossDefense * 1.4) && bc.character.defense > bc.character.bossAttack * 1.4)
+                        if (bc.character.defense/20-bc.character.bossAttack+bc.character.defense > bc.character.bossDefense/20-bc.character.attack+bc.character.bossDefense)
                         {
                             bc.beginFight();
                             bc.stopButton.gameObject.SetActive(true);


### PR DESCRIPTION
## Previous logic

```py
if playerattack > 1.4*bossdefense and playerdefense > 1.4*bossattack:
    FIGHT
```

To me that seems very arbitrary and does not make any sense. Furthermore, the resulting behavior is very passive.

Consider the following example:

Player:  
50 Attack (500 HP)  
1 Defense  (0.05 HP/s regen)

Boss:  
1 Attack (10 HP)  
1 Defense (0.05 HP/s regen)

Assuming that the damage is done is Attack-Defense-Regen, the player would do 48.95 dps and kill that boss within 0.204 seconds whereas the boss would be completely unable to do any damage. However, because the 1 defense of the player is smaller than 1.4*bossattack, i.e. 1.4, **the fight would _not_ get initiated**.

As far as I can tell, there is no benefit to being at full health, therefore it makes more sense to fight bosses as aggressively as possible to get to the next boss as early as possible.

## New logic

```py
if playerdefense/20 - bossattack + playerdefense > bossdefense/20 - playerattack + bossdefense:
    FIGHT
```
or, interpreted differently  
```py
playerregen = playerdefense/20  
bossregen = bossdefense/20  
playerdamagetaken = bossattack-playerdefense
bossdamagetaken = playerattack-bossdefense
if playerregen - playerdamagetaken > bossregen - bossdamagetaken:
    FIGHT
```
Assuming we're looking at the previous example, the equation would be `1/20 - 1 + 1 > 1/20 - 50 + 1` or `0.05 > -48.95` and the fight would be initiated.

Let's look at a different example:

Player:  
1.5 Attack (15 HP)  
1.5 Defense (0.075 HP/s regen)  

Boss:  
2 Attack (20 HP)  
1 Defense (0.05 HP/s regen)

The fight would be initiated because `1.5/20 - 2 + 1.5 > 1/20 - 1.5 + 1` or `-0.425 > -0.45`. What would such a fight look like, assuming the unrealistic scenario that player attack/defense are constant instead of increasing because of basic training?
|Time (s)|Player health|Boss health|Comment|  
|---|---|---|---|
|0|100% - 15|100% - 20|The logic equates to True and the fight gets initiated|  
|10|71.7% - 10.75|77.5% - 15.5|Next loop starts|
|20|43.3% - 6.5|55.0% - 11|Next loop starts|
|30|15.0% - 2.25|32.5% - 6.5|Next loop starts|
|35.29|0.0% - 0|20.6% - 4.12|Player runs out of health, fight is over|
|40|2.3% - 0.35|21.8% - 4.35|Next loop starts, the logic equates to True and the fight gets initiated|  
|40.83|0.0% - 0|19.9% - 3.98|Player runs out of health, fight is over|
|50|4.6% - 0.69|22.2% - 4.44|Next loop starts, the logic equates to True and the fight gets initiated|
|51.62|0.0% - 0|18.5% - 3.71|Player runs out of health, fight is over|
|60|4.2% - 0.63|20.6% - 4.13|Next loop starts, the logic equates to True and the fight gets initiated|
|61.48|0.0% - 0|17.3% - 3.46|Player runs out of health, fight is over|

The player is making steady progress at whittling down the boss's health, eventually **the fight will be won** and the player advances to the next boss.