### PR TITLE
Quest Loadouts

### DIFF
--- a/NGUInjector/Main.cs
+++ b/NGUInjector/Main.cs
@@ -187,6 +187,8 @@ namespace NGUInjector
                         PriorityBoosts = new int[] { },
                         YggdrasilLoadout = new int[] { },
                         SwapYggdrasilLoadouts = false,
+                        QuestLoadout = new int[] { },
+                        SwapQuestLoadout = false,
                         SwapTitanLoadouts = false,
                         TitanLoadout = new int[] { },
                         ManageDiggers = true,

--- a/NGUInjector/Managers/LoadoutManager.cs
+++ b/NGUInjector/Managers/LoadoutManager.cs
@@ -12,6 +12,7 @@ namespace NGUInjector.Managers
         Yggdrasil,
         MoneyPit,
         Gold,
+        Quest,
         None
     }
     internal static class LoadoutManager
@@ -98,6 +99,21 @@ namespace NGUInjector.Managers
             AcquireLock(LockType.Yggdrasil);
             SaveCurrentLoadout();
             ChangeGear(Settings.YggdrasilLoadout);
+            return true;
+        }
+
+        internal static bool TryQuestSwap()
+        {
+            if (!CanAcquireOrHasLock(LockType.Quest))
+                return false;
+
+            if (CurrentLock == LockType.Quest)
+                return true;
+
+            Log("Equipping Quest Loadout");
+            AcquireLock(LockType.Quest);
+            SaveCurrentLoadout();
+            ChangeGear(Settings.QuestLoadout);
             return true;
         }
 

--- a/NGUInjector/Managers/QuestManager.cs
+++ b/NGUInjector/Managers/QuestManager.cs
@@ -81,14 +81,17 @@ namespace NGUInjector.Managers
                 {
                     _character.settings.useMajorQuests = true;
                     SetIdleMode(false);
-                    _character.beastQuestController.startQuest();
                 }
                 else
                 {
                     _character.settings.useMajorQuests = false;
                     SetIdleMode(!Settings.ManualMinors);
-                    _character.beastQuestController.startQuest();
                 }
+
+
+                Log("Starting Quest");
+
+                _character.beastQuestController.startQuest();
 
                 return;
             }
@@ -98,13 +101,15 @@ namespace NGUInjector.Managers
             {
                 if (Settings.AllowMajorQuests && Settings.AbandonMinors && _character.beastQuest.curBankedQuests > 0)
                 {
-                    var progress = (_character.beastQuest.curDrops / (float) _character.beastQuest.targetDrops) * 100;
-                    if ( progress <= Settings.MinorAbandonThreshold)
+                    var progress = (_character.beastQuest.curDrops / (float)_character.beastQuest.targetDrops) * 100;
+                    if (progress <= Settings.MinorAbandonThreshold)
                     {
                         //If all this is true get rid of this minor quest and pick up a new one.
                         _character.settings.useMajorQuests = true;
                         _character.beastQuestController.skipQuest();
                         SetIdleMode(false);
+
+
                         _character.beastQuestController.startQuest();
                         //Combat logic will pick up from here
                         return;
@@ -116,9 +121,25 @@ namespace NGUInjector.Managers
                 }
 
                 SetIdleMode(!Settings.ManualMinors);
+
+                if (Settings.ManualMinors && Settings.SwapQuestLoadout && Settings.QuestLoadout.Length > 0)
+                {
+                    // Swap gear for minor quests if manual minors and swap gear for quests are both true
+                    LoadoutManager.TryQuestSwap();
+                }
+                else if (LoadoutManager.CurrentLock == LockType.Quest)
+                {
+                    LoadoutManager.RestoreGear();
+                    LoadoutManager.ReleaseLock();
+                }
             }
             else
             {
+
+                if (Settings.SwapQuestLoadout && Settings.QuestLoadout.Length > 0)
+                {
+                    LoadoutManager.TryQuestSwap();
+                }
                 SetIdleMode(false);
             }
         }

--- a/NGUInjector/SavedSettings.cs
+++ b/NGUInjector/SavedSettings.cs
@@ -93,6 +93,8 @@ namespace NGUInjector
         [SerializeField] private int[] _specialBoostBlacklist;
         [SerializeField] private int[] _blacklistedBosses;
         [SerializeField] private bool _hackAdvance;
+        [SerializeField] private int[] _questLoadout;
+        [SerializeField] private bool _swapQuestLoadout;
 
         private readonly string _savePath;
         private bool _disableSave;
@@ -195,6 +197,8 @@ namespace NGUInjector
             _minorAbandonThreshold = other.MinorAbandonThreshold;
             _questCombatMode = other.QuestCombatMode;
             _questFastCombat = other.QuestFastCombat;
+            _questLoadout = other.QuestLoadout;
+            _swapQuestLoadout = other.SwapQuestLoadout;
             _autoSpellSwap = other.AutoSpellSwap;
             _counterfeitThreshold = other.CounterfeitThreshold;
             _spaghettiThreshold = other.SpaghettiThreshold;
@@ -285,6 +289,16 @@ namespace NGUInjector
             }
         }
 
+        public bool SwapQuestLoadout
+        {
+            get => _swapQuestLoadout;
+            set
+            {
+                if (value == _swapQuestLoadout) return;
+                _swapQuestLoadout = value; SaveSettings();
+            }
+        }
+
         public int[] PriorityBoosts
         {
             get => _priorityBoosts;
@@ -348,6 +362,16 @@ namespace NGUInjector
             set
             {
                 _yggdrasilLoadout = value;
+                SaveSettings();
+            }
+        }
+
+        public int[] QuestLoadout
+        {
+            get => _questLoadout;
+            set
+            {
+                _questLoadout = value;
                 SaveSettings();
             }
         }

--- a/NGUInjector/SettingsForm.Designer.cs
+++ b/NGUInjector/SettingsForm.Designer.cs
@@ -32,6 +32,7 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsForm));
             this.moneyPitError = new System.Windows.Forms.ErrorProvider(this.components);
             this.yggErrorProvider = new System.Windows.Forms.ErrorProvider(this.components);
+            this.questErrorProvider = new System.Windows.Forms.ErrorProvider(this.components);
             this.invPrioErrorProvider = new System.Windows.Forms.ErrorProvider(this.components);
             this.invBlacklistErrProvider = new System.Windows.Forms.ErrorProvider(this.components);
             this.titanErrProvider = new System.Windows.Forms.ErrorProvider(this.components);
@@ -174,6 +175,11 @@
             this.GoldLoadoutAdd = new System.Windows.Forms.Button();
             this.GoldLoadout = new System.Windows.Forms.ListBox();
             this.tabPage8 = new System.Windows.Forms.TabPage();
+            this.questRemoveButton = new System.Windows.Forms.Button();
+            this.questLoadoutItem = new System.Windows.Forms.NumericUpDown();
+            this.questItemLabel = new System.Windows.Forms.Label();
+            this.questAddButton = new System.Windows.Forms.Button();
+            this.questLoadoutBox = new System.Windows.Forms.ListBox();
             this.ButterMinors = new System.Windows.Forms.CheckBox();
             this.ButterMajors = new System.Windows.Forms.CheckBox();
             this.ManualMinor = new System.Windows.Forms.CheckBox();
@@ -210,8 +216,10 @@
             this.AutoDailySpin = new System.Windows.Forms.CheckBox();
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.QuestSwap = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.moneyPitError)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.yggErrorProvider)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.questErrorProvider)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.invPrioErrorProvider)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.invBlacklistErrProvider)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.titanErrProvider)).BeginInit();
@@ -239,6 +247,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.ResnipeInput)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.GoldItemBox)).BeginInit();
             this.tabPage8.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.questLoadoutItem)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.AbandonMinorThreshold)).BeginInit();
             this.tabPage9.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.WishAddInput)).BeginInit();
@@ -254,6 +263,10 @@
             // yggErrorProvider
             // 
             this.yggErrorProvider.ContainerControl = this;
+            // 
+            // questErrorProvider
+            // 
+            this.questErrorProvider.ContainerControl = this;
             // 
             // invPrioErrorProvider
             // 
@@ -1384,6 +1397,12 @@
             // 
             // tabPage8
             // 
+            this.tabPage8.Controls.Add(this.QuestSwap);
+            this.tabPage8.Controls.Add(this.questRemoveButton);
+            this.tabPage8.Controls.Add(this.questLoadoutItem);
+            this.tabPage8.Controls.Add(this.questItemLabel);
+            this.tabPage8.Controls.Add(this.questAddButton);
+            this.tabPage8.Controls.Add(this.questLoadoutBox);
             this.tabPage8.Controls.Add(this.ButterMinors);
             this.tabPage8.Controls.Add(this.ButterMajors);
             this.tabPage8.Controls.Add(this.ManualMinor);
@@ -1398,6 +1417,56 @@
             resources.ApplyResources(this.tabPage8, "tabPage8");
             this.tabPage8.Name = "tabPage8";
             this.tabPage8.UseVisualStyleBackColor = true;
+            // 
+            // questRemoveButton
+            // 
+            resources.ApplyResources(this.questRemoveButton, "questRemoveButton");
+            this.questRemoveButton.Name = "questRemoveButton";
+            this.questRemoveButton.UseVisualStyleBackColor = true;
+            this.questRemoveButton.Click += new System.EventHandler(this.questRemoveButton_Click);
+            // 
+            // questLoadoutItem
+            // 
+            this.questLoadoutItem.CausesValidation = false;
+            resources.ApplyResources(this.questLoadoutItem, "questLoadoutItem");
+            this.questLoadoutItem.Maximum = new decimal(new int[] {
+            9999999,
+            0,
+            0,
+            0});
+            this.questLoadoutItem.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.questLoadoutItem.Name = "questLoadoutItem";
+            this.questLoadoutItem.Value = new decimal(new int[] {
+            40,
+            0,
+            0,
+            0});
+            this.questLoadoutItem.KeyDown += new System.Windows.Forms.KeyEventHandler(this.questLoadoutItem_KeyDown);
+            // 
+            // questItemLabel
+            // 
+            resources.ApplyResources(this.questItemLabel, "questItemLabel");
+            this.questItemLabel.Name = "questItemLabel";
+            // 
+            // questAddButton
+            // 
+            resources.ApplyResources(this.questAddButton, "questAddButton");
+            this.questAddButton.Name = "questAddButton";
+            this.questAddButton.UseVisualStyleBackColor = true;
+            this.questAddButton.Click += new System.EventHandler(this.questAddButton_Click);
+            // 
+            // questLoadoutBox
+            // 
+            this.questLoadoutBox.FormattingEnabled = true;
+            this.questLoadoutBox.Items.AddRange(new object[] {
+            resources.GetString("questLoadoutBox.Items"),
+            resources.GetString("questLoadoutBox.Items1")});
+            resources.ApplyResources(this.questLoadoutBox, "questLoadoutBox");
+            this.questLoadoutBox.Name = "questLoadoutBox";
             // 
             // ButterMinors
             // 
@@ -1681,6 +1750,13 @@
             resources.ApplyResources(this.flowLayoutPanel1, "flowLayoutPanel1");
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             // 
+            // QuestSwap
+            // 
+            resources.ApplyResources(this.QuestSwap, "QuestSwap");
+            this.QuestSwap.Name = "QuestSwap";
+            this.QuestSwap.UseVisualStyleBackColor = true;
+            this.QuestSwap.CheckedChanged += new System.EventHandler(this.QuestSwap_CheckedChanged);
+            // 
             // SettingsForm
             // 
             resources.ApplyResources(this, "$this");
@@ -1693,6 +1769,7 @@
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.SettingsForm_FormClosing);
             ((System.ComponentModel.ISupportInitialize)(this.moneyPitError)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.yggErrorProvider)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.questErrorProvider)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.invPrioErrorProvider)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.invBlacklistErrProvider)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.titanErrProvider)).EndInit();
@@ -1728,6 +1805,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.GoldItemBox)).EndInit();
             this.tabPage8.ResumeLayout(false);
             this.tabPage8.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.questLoadoutItem)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.AbandonMinorThreshold)).EndInit();
             this.tabPage9.ResumeLayout(false);
             this.tabPage9.PerformLayout();
@@ -1743,6 +1821,7 @@
         #endregion
         private System.Windows.Forms.ErrorProvider moneyPitError;
         private System.Windows.Forms.ErrorProvider yggErrorProvider;
+        private System.Windows.Forms.ErrorProvider questErrorProvider;
         private System.Windows.Forms.ErrorProvider invPrioErrorProvider;
         private System.Windows.Forms.ErrorProvider invBlacklistErrProvider;
         private System.Windows.Forms.ErrorProvider titanErrProvider;
@@ -1921,5 +2000,11 @@
         private System.Windows.Forms.CheckBox WishSortOrder;
         private System.Windows.Forms.CheckBox WishSortPriorities;
         private System.Windows.Forms.Button ProfileEditButton;
+        private System.Windows.Forms.Button questRemoveButton;
+        private System.Windows.Forms.NumericUpDown questLoadoutItem;
+        private System.Windows.Forms.Label questItemLabel;
+        private System.Windows.Forms.Button questAddButton;
+        private System.Windows.Forms.ListBox questLoadoutBox;
+        private System.Windows.Forms.CheckBox QuestSwap;
     }
 }

--- a/NGUInjector/SettingsForm.Designer.cs
+++ b/NGUInjector/SettingsForm.Designer.cs
@@ -175,6 +175,7 @@
             this.GoldLoadoutAdd = new System.Windows.Forms.Button();
             this.GoldLoadout = new System.Windows.Forms.ListBox();
             this.tabPage8 = new System.Windows.Forms.TabPage();
+            this.QuestSwap = new System.Windows.Forms.CheckBox();
             this.questRemoveButton = new System.Windows.Forms.Button();
             this.questLoadoutItem = new System.Windows.Forms.NumericUpDown();
             this.questItemLabel = new System.Windows.Forms.Label();
@@ -216,7 +217,7 @@
             this.AutoDailySpin = new System.Windows.Forms.CheckBox();
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-            this.QuestSwap = new System.Windows.Forms.CheckBox();
+            this.label1 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.moneyPitError)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.yggErrorProvider)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.questErrorProvider)).BeginInit();
@@ -727,10 +728,10 @@
             // yggdrasilLoadoutBox
             // 
             this.yggdrasilLoadoutBox.FormattingEnabled = true;
+            resources.ApplyResources(this.yggdrasilLoadoutBox, "yggdrasilLoadoutBox");
             this.yggdrasilLoadoutBox.Items.AddRange(new object[] {
             resources.GetString("yggdrasilLoadoutBox.Items"),
             resources.GetString("yggdrasilLoadoutBox.Items1")});
-            resources.ApplyResources(this.yggdrasilLoadoutBox, "yggdrasilLoadoutBox");
             this.yggdrasilLoadoutBox.Name = "yggdrasilLoadoutBox";
             // 
             // YggdrasilSwap
@@ -848,10 +849,10 @@
             // blacklistBox
             // 
             this.blacklistBox.FormattingEnabled = true;
+            resources.ApplyResources(this.blacklistBox, "blacklistBox");
             this.blacklistBox.Items.AddRange(new object[] {
             resources.GetString("blacklistBox.Items"),
             resources.GetString("blacklistBox.Items1")});
-            resources.ApplyResources(this.blacklistBox, "blacklistBox");
             this.blacklistBox.Name = "blacklistBox";
             // 
             // label2
@@ -897,10 +898,10 @@
             // priorityBoostBox
             // 
             this.priorityBoostBox.FormattingEnabled = true;
+            resources.ApplyResources(this.priorityBoostBox, "priorityBoostBox");
             this.priorityBoostBox.Items.AddRange(new object[] {
             resources.GetString("priorityBoostBox.Items"),
             resources.GetString("priorityBoostBox.Items1")});
-            resources.ApplyResources(this.priorityBoostBox, "priorityBoostBox");
             this.priorityBoostBox.Name = "priorityBoostBox";
             // 
             // ManageInventory
@@ -996,10 +997,10 @@
             // titanLoadout
             // 
             this.titanLoadout.FormattingEnabled = true;
+            resources.ApplyResources(this.titanLoadout, "titanLoadout");
             this.titanLoadout.Items.AddRange(new object[] {
             resources.GetString("titanLoadout.Items"),
             resources.GetString("titanLoadout.Items1")});
-            resources.ApplyResources(this.titanLoadout, "titanLoadout");
             this.titanLoadout.Name = "titanLoadout";
             // 
             // SwapTitanLoadout
@@ -1389,14 +1390,15 @@
             // GoldLoadout
             // 
             this.GoldLoadout.FormattingEnabled = true;
+            resources.ApplyResources(this.GoldLoadout, "GoldLoadout");
             this.GoldLoadout.Items.AddRange(new object[] {
             resources.GetString("GoldLoadout.Items"),
             resources.GetString("GoldLoadout.Items1")});
-            resources.ApplyResources(this.GoldLoadout, "GoldLoadout");
             this.GoldLoadout.Name = "GoldLoadout";
             // 
             // tabPage8
             // 
+            this.tabPage8.Controls.Add(this.label1);
             this.tabPage8.Controls.Add(this.QuestSwap);
             this.tabPage8.Controls.Add(this.questRemoveButton);
             this.tabPage8.Controls.Add(this.questLoadoutItem);
@@ -1417,6 +1419,13 @@
             resources.ApplyResources(this.tabPage8, "tabPage8");
             this.tabPage8.Name = "tabPage8";
             this.tabPage8.UseVisualStyleBackColor = true;
+            // 
+            // QuestSwap
+            // 
+            resources.ApplyResources(this.QuestSwap, "QuestSwap");
+            this.QuestSwap.Name = "QuestSwap";
+            this.QuestSwap.UseVisualStyleBackColor = true;
+            this.QuestSwap.CheckedChanged += new System.EventHandler(this.QuestSwap_CheckedChanged);
             // 
             // questRemoveButton
             // 
@@ -1462,10 +1471,10 @@
             // questLoadoutBox
             // 
             this.questLoadoutBox.FormattingEnabled = true;
+            resources.ApplyResources(this.questLoadoutBox, "questLoadoutBox");
             this.questLoadoutBox.Items.AddRange(new object[] {
             resources.GetString("questLoadoutBox.Items"),
             resources.GetString("questLoadoutBox.Items1")});
-            resources.ApplyResources(this.questLoadoutBox, "questLoadoutBox");
             this.questLoadoutBox.Name = "questLoadoutBox";
             // 
             // ButterMinors
@@ -1635,10 +1644,10 @@
             // WishPriority
             // 
             this.WishPriority.FormattingEnabled = true;
+            resources.ApplyResources(this.WishPriority, "WishPriority");
             this.WishPriority.Items.AddRange(new object[] {
             resources.GetString("WishPriority.Items"),
             resources.GetString("WishPriority.Items1")});
-            resources.ApplyResources(this.WishPriority, "WishPriority");
             this.WishPriority.Name = "WishPriority";
             // 
             // tabPage10
@@ -1700,10 +1709,10 @@
             // MoneyPitLoadout
             // 
             this.MoneyPitLoadout.FormattingEnabled = true;
+            resources.ApplyResources(this.MoneyPitLoadout, "MoneyPitLoadout");
             this.MoneyPitLoadout.Items.AddRange(new object[] {
             resources.GetString("MoneyPitLoadout.Items"),
             resources.GetString("MoneyPitLoadout.Items1")});
-            resources.ApplyResources(this.MoneyPitLoadout, "MoneyPitLoadout");
             this.MoneyPitLoadout.Name = "MoneyPitLoadout";
             // 
             // MoneyPitThresholdSave
@@ -1750,12 +1759,10 @@
             resources.ApplyResources(this.flowLayoutPanel1, "flowLayoutPanel1");
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             // 
-            // QuestSwap
+            // label1
             // 
-            resources.ApplyResources(this.QuestSwap, "QuestSwap");
-            this.QuestSwap.Name = "QuestSwap";
-            this.QuestSwap.UseVisualStyleBackColor = true;
-            this.QuestSwap.CheckedChanged += new System.EventHandler(this.QuestSwap_CheckedChanged);
+            resources.ApplyResources(this.label1, "label1");
+            this.label1.Name = "label1";
             // 
             // SettingsForm
             // 
@@ -2006,5 +2013,6 @@
         private System.Windows.Forms.Button questAddButton;
         private System.Windows.Forms.ListBox questLoadoutBox;
         private System.Windows.Forms.CheckBox QuestSwap;
+        private System.Windows.Forms.Label label1;
     }
 }

--- a/NGUInjector/SettingsForm.cs
+++ b/NGUInjector/SettingsForm.cs
@@ -31,7 +31,7 @@ namespace NGUInjector
             {
                 {0, "None"}, {1, "Balanced"}, {2, "Power"}, {3, "Toughness"}
             };
-            CombatModeList = new Dictionary<int, string> {{0, "Manual"}, {1, "Idle"}};
+            CombatModeList = new Dictionary<int, string> { { 0, "Manual" }, { 1, "Idle" } };
             TitanList = new Dictionary<int, string>
             {
                 {0, "None"},
@@ -48,7 +48,7 @@ namespace NGUInjector
                 {11, "Rock Lobster"},
                 {12, "Amalgamate"}
             };
-            
+
             ZoneList = new Dictionary<int, string>
             {
                 {-1, "Safe Zone: Awakening Site"},
@@ -133,19 +133,20 @@ namespace NGUInjector
             CombatTargetZone.DataSource = new BindingSource(ZoneList, null);
             CombatTargetZone.ValueMember = "Key";
             CombatTargetZone.DisplayMember = "Value";
-            
+
             //Remove ITOPOD for non combat zones
             ZoneList.Remove(1000);
             ZoneList.Remove(-1);
 
             EnemyBlacklistZone.ValueMember = "Key";
             EnemyBlacklistZone.DisplayMember = "Value";
-            EnemyBlacklistZone.DataSource = new BindingSource(ZoneList.Where(x => !ZoneHelpers.TitanZones.Contains(x.Key) ).ToDictionary(x => x.Key, x=> x.Value), null);
+            EnemyBlacklistZone.DataSource = new BindingSource(ZoneList.Where(x => !ZoneHelpers.TitanZones.Contains(x.Key)).ToDictionary(x => x.Key, x => x.Value), null);
             EnemyBlacklistZone.SelectedIndex = 0;
 
 
             blacklistLabel.Text = "";
             yggItemLabel.Text = "";
+            questItemLabel.Text = "";
             priorityBoostLabel.Text = "";
             titanLabel.Text = "";
             GoldItemLabel.Text = "";
@@ -216,7 +217,7 @@ namespace NGUInjector
         {
             control.SelectedIndex = setting >= 1000 ? 43 : setting + 1;
         }
-        
+
         internal void UpdateFromSettings(SavedSettings newSettings)
         {
             _initializing = true;
@@ -224,7 +225,7 @@ namespace NGUInjector
             AutoFightBosses.Checked = newSettings.AutoFight;
             AutoITOPOD.Checked = newSettings.AutoQuestITOPOD;
             AutoMoneyPit.Checked = newSettings.AutoMoneyPit;
-            MoneyPitThreshold.Text = $"{newSettings.MoneyPitThreshold:#.##E+00}"; 
+            MoneyPitThreshold.Text = $"{newSettings.MoneyPitThreshold:#.##E+00}";
             ManageEnergy.Checked = newSettings.ManageEnergy;
             ManageMagic.Checked = newSettings.ManageMagic;
             ManageGear.Checked = newSettings.ManageGear;
@@ -233,6 +234,7 @@ namespace NGUInjector
             AutoRebirth.Checked = newSettings.AutoRebirth;
             ManageYggdrasil.Checked = newSettings.ManageYggdrasil;
             YggdrasilSwap.Checked = newSettings.SwapYggdrasilLoadouts;
+            QuestSwap.Checked = newSettings.SwapQuestLoadout;
             ManageInventory.Checked = newSettings.ManageInventory;
             ManageBoostConvert.Checked = newSettings.AutoConvertBoosts;
             SwapTitanLoadout.Checked = newSettings.SwapTitanLoadouts;
@@ -305,7 +307,20 @@ namespace NGUInjector
             {
                 yggdrasilLoadoutBox.Items.Clear();
             }
-            
+
+            temp = newSettings.QuestLoadout.ToDictionary(x => x, x => Main.Character.itemInfo.itemName[x]);
+            if (temp.Count > 0)
+            {
+                questLoadoutBox.DataSource = null;
+                questLoadoutBox.DataSource = new BindingSource(temp, null);
+                questLoadoutBox.ValueMember = "Key";
+                questLoadoutBox.DisplayMember = "Value";
+            }
+            else
+            {
+                questLoadoutBox.Items.Clear();
+            }
+
 
             temp = newSettings.PriorityBoosts.ToDictionary(x => x, x => Main.Character.itemInfo.itemName[x]);
             if (temp.Count > 0)
@@ -319,7 +334,7 @@ namespace NGUInjector
             {
                 priorityBoostBox.Items.Clear();
             }
-            
+
             temp = newSettings.BoostBlacklist.ToDictionary(x => x, x => Main.Character.itemInfo.itemName[x]);
             if (temp.Count > 0)
             {
@@ -547,7 +562,7 @@ namespace NGUInjector
         private void yggRemoveButton_Click(object sender, EventArgs e)
         {
             yggErrorProvider.SetError(yggLoadoutItem, "");
-            var item= yggdrasilLoadoutBox.SelectedItem;
+            var item = yggdrasilLoadoutBox.SelectedItem;
             if (item == null)
                 return;
 
@@ -750,7 +765,7 @@ namespace NGUInjector
         {
             if (_initializing) return;
             var selected = CombatTargetZone.SelectedItem;
-            var item = (KeyValuePair<int, string>) selected;
+            var item = (KeyValuePair<int, string>)selected;
             Main.Settings.SnipeZone = item.Key;
         }
 
@@ -926,7 +941,7 @@ namespace NGUInjector
                 temp.Add(val);
                 Main.Settings.YggdrasilLoadout = temp.ToArray();
             }
-            
+
         }
 
         private void titanAddItem_KeyDown(object sender, KeyEventArgs e)
@@ -1060,7 +1075,7 @@ namespace NGUInjector
             var temp = Main.Settings.WishPriorities.ToList();
             var item = temp[index];
             temp.RemoveAt(index);
-            temp.Insert(index -1, item);
+            temp.Insert(index - 1, item);
             Main.Settings.WishPriorities = temp.ToArray();
             WishPriority.SelectedIndex = index - 1;
         }
@@ -1356,7 +1371,7 @@ namespace NGUInjector
         private void EnemyBlacklistZone_SelectedIndexChanged(object sender, EventArgs e)
         {
             var selected = EnemyBlacklistZone.SelectedItem;
-            var item = (KeyValuePair<int, string>) selected;
+            var item = (KeyValuePair<int, string>)selected;
             var values = Main.Character.adventureController.enemyList[item.Key]
                 .Select(x => new KeyValuePair<int, string>(x.spriteID, x.name)).ToList();
             EnemyBlacklistNames.DataSource = null;
@@ -1411,6 +1426,67 @@ namespace NGUInjector
             var filename = Main.Settings.AllocationFile + ".json";
             var path = Path.Combine(Main.GetProfilesDir(), filename);
             Process.Start(path);
+        }
+
+        private void questRemoveButton_Click(object sender, EventArgs e)
+        {
+
+            questErrorProvider.SetError(questLoadoutItem, "");
+            var item = questLoadoutBox.SelectedItem;
+            if (item == null)
+                return;
+
+            var id = (KeyValuePair<int, string>)item;
+
+            var temp = Main.Settings.QuestLoadout.ToList();
+            temp.RemoveAll(x => x == id.Key);
+            Main.Settings.QuestLoadout = temp.ToArray();
+        }
+
+        private void questAddButton_Click(object sender, EventArgs e)
+        {
+
+            questErrorProvider.SetError(questLoadoutItem, "");
+            var val = decimal.ToInt32(questLoadoutItem.Value);
+            if (val < 40 || val > Consts.MAX_GEAR_ID)
+            {
+                questErrorProvider.SetError(questLoadoutItem, "Not a valid item id");
+                return;
+            }
+
+            if (Main.Settings.QuestLoadout.Contains(val))
+                return;
+            var temp = Main.Settings.QuestLoadout.ToList();
+            temp.Add(val);
+            Main.Settings.QuestLoadout = temp.ToArray();
+        }
+
+        private void QuestSwap_CheckedChanged(object sender, EventArgs e)
+        {
+            if (_initializing) return;
+            Main.Settings.SwapQuestLoadout = QuestSwap.Checked;
+        }
+
+        private void questLoadoutItem_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter)
+            {
+                questErrorProvider.SetError(questLoadoutItem, "");
+                var val = decimal.ToInt32(questLoadoutItem.Value);
+                if (val < 40 || val > Consts.MAX_GEAR_ID)
+                {
+                    questErrorProvider.SetError(questLoadoutItem, "Not a valid item id");
+                    return;
+                }
+
+                ActiveControl = questItemLabel;
+
+                if (Main.Settings.QuestLoadout.Contains(val))
+                    return;
+                var temp = Main.Settings.QuestLoadout.ToList();
+                temp.Add(val);
+
+            }
         }
     }
 }

--- a/NGUInjector/SettingsForm.cs
+++ b/NGUInjector/SettingsForm.cs
@@ -158,6 +158,7 @@ namespace NGUInjector
             GoldItemBox.TextChanged += GoldItemBox_TextChanged;
             WishAddInput.TextChanged += WishAddInput_TextChanged;
             MoneyPitInput.TextChanged += MoneyPitLoadout_TextChanged;
+            questLoadoutItem.TextChanged += questLoadoutItem_TextChanged;
 
             prioUpButton.Text = char.ConvertFromUtf32(8593);
             prioDownButton.Text = char.ConvertFromUtf32(8595);
@@ -1441,6 +1442,16 @@ namespace NGUInjector
             var temp = Main.Settings.QuestLoadout.ToList();
             temp.RemoveAll(x => x == id.Key);
             Main.Settings.QuestLoadout = temp.ToArray();
+        }
+
+        private void questLoadoutItem_TextChanged(object sender, EventArgs e)
+        {
+            questErrorProvider.SetError(questLoadoutItem, "");
+            var val = decimal.ToInt32(questLoadoutItem.Value);
+            if (val < 40 || val > Consts.MAX_GEAR_ID)
+                return;
+            var itemName = Main.Character.itemInfo.itemName[val];
+            questItemLabel.Text = itemName;
         }
 
         private void questAddButton_Click(object sender, EventArgs e)

--- a/NGUInjector/SettingsForm.resx
+++ b/NGUInjector/SettingsForm.resx
@@ -112,35 +112,41 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="moneyPitError.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+  <metadata name="moneyPitError.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>231, 17</value>
   </metadata>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>77</value>
+  </metadata>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>9, 20</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>605, 387</value>
+    <value>908, 595</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="progressBar1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="progressBar1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>4, 5</value>
+  </data>
+  <data name="progressBar1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="progressBar1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>598, 13</value>
+    <value>897, 20</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="progressBar1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
@@ -148,7 +154,7 @@
     <value>progressBar1</value>
   </data>
   <data name="&gt;&gt;progressBar1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ProgressBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;progressBar1.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -160,10 +166,13 @@
     <value>True</value>
   </data>
   <data name="DisableOverlay.Location" type="System.Drawing.Point, System.Drawing">
-    <value>106, 6</value>
+    <value>159, 9</value>
+  </data>
+  <data name="DisableOverlay.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="DisableOverlay.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 17</value>
+    <value>144, 24</value>
   </data>
   <data name="DisableOverlay.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -175,7 +184,7 @@
     <value>DisableOverlay</value>
   </data>
   <data name="&gt;&gt;DisableOverlay.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;DisableOverlay.Parent" xml:space="preserve">
     <value>tabPage1</value>
@@ -190,10 +199,13 @@
     <value>NoControl</value>
   </data>
   <data name="UnloadSafety.Location" type="System.Drawing.Point, System.Drawing">
-    <value>396, 310</value>
+    <value>594, 477</value>
+  </data>
+  <data name="UnloadSafety.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="UnloadSafety.Size" type="System.Drawing.Size, System.Drawing">
-    <value>15, 14</value>
+    <value>22, 21</value>
   </data>
   <data name="UnloadSafety.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -202,7 +214,7 @@
     <value>UnloadSafety</value>
   </data>
   <data name="&gt;&gt;UnloadSafety.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;UnloadSafety.Parent" xml:space="preserve">
     <value>tabPage1</value>
@@ -217,10 +229,13 @@
     <value>NoControl</value>
   </data>
   <data name="UnloadButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>417, 305</value>
+    <value>626, 469</value>
+  </data>
+  <data name="UnloadButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="UnloadButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>112, 35</value>
   </data>
   <data name="UnloadButton.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -232,7 +247,7 @@
     <value>UnloadButton</value>
   </data>
   <data name="&gt;&gt;UnloadButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;UnloadButton.Parent" xml:space="preserve">
     <value>tabPage1</value>
@@ -247,10 +262,13 @@
     <value>NoControl</value>
   </data>
   <data name="VersionLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>498, 310</value>
+    <value>747, 477</value>
+  </data>
+  <data name="VersionLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="VersionLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
+    <value>106, 20</value>
   </data>
   <data name="VersionLabel.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -262,7 +280,7 @@
     <value>VersionLabel</value>
   </data>
   <data name="&gt;&gt;VersionLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;VersionLabel.Parent" xml:space="preserve">
     <value>tabPage1</value>
@@ -277,10 +295,13 @@
     <value>NoControl</value>
   </data>
   <data name="AutoBuyEM.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 74</value>
+    <value>8, 114</value>
+  </data>
+  <data name="AutoBuyEM.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="AutoBuyEM.Size" type="System.Drawing.Size, System.Drawing">
-    <value>158, 17</value>
+    <value>225, 24</value>
   </data>
   <data name="AutoBuyEM.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -292,7 +313,7 @@
     <value>AutoBuyEM</value>
   </data>
   <data name="&gt;&gt;AutoBuyEM.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoBuyEM.Parent" xml:space="preserve">
     <value>tabPage1</value>
@@ -307,10 +328,13 @@
     <value>NoControl</value>
   </data>
   <data name="MasterEnable.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 6</value>
+    <value>9, 9</value>
+  </data>
+  <data name="MasterEnable.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="MasterEnable.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 17</value>
+    <value>135, 24</value>
   </data>
   <data name="MasterEnable.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -322,7 +346,7 @@
     <value>MasterEnable</value>
   </data>
   <data name="&gt;&gt;MasterEnable.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MasterEnable.Parent" xml:space="preserve">
     <value>tabPage1</value>
@@ -337,10 +361,13 @@
     <value>NoControl</value>
   </data>
   <data name="AutoFightBosses.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 52</value>
+    <value>9, 80</value>
+  </data>
+  <data name="AutoFightBosses.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="AutoFightBosses.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 17</value>
+    <value>166, 24</value>
   </data>
   <data name="AutoFightBosses.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -352,7 +379,7 @@
     <value>AutoFightBosses</value>
   </data>
   <data name="&gt;&gt;AutoFightBosses.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoFightBosses.Parent" xml:space="preserve">
     <value>tabPage1</value>
@@ -367,10 +394,13 @@
     <value>NoControl</value>
   </data>
   <data name="AutoITOPOD.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 29</value>
+    <value>9, 45</value>
+  </data>
+  <data name="AutoITOPOD.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="AutoITOPOD.Size" type="System.Drawing.Size, System.Drawing">
-    <value>134, 17</value>
+    <value>193, 24</value>
   </data>
   <data name="AutoITOPOD.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -382,7 +412,7 @@
     <value>AutoITOPOD</value>
   </data>
   <data name="&gt;&gt;AutoITOPOD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoITOPOD.Parent" xml:space="preserve">
     <value>tabPage1</value>
@@ -391,13 +421,16 @@
     <value>7</value>
   </data>
   <data name="tabPage1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="tabPage1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>590, 334</value>
+    <value>889, 521</value>
   </data>
   <data name="tabPage1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -409,7 +442,7 @@
     <value>tabPage1</value>
   </data>
   <data name="&gt;&gt;tabPage1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage1.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -418,10 +451,13 @@
     <value>0</value>
   </data>
   <data name="ProfileEditButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>503, 13</value>
+    <value>754, 20</value>
+  </data>
+  <data name="ProfileEditButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ProfileEditButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>112, 35</value>
   </data>
   <data name="ProfileEditButton.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
@@ -433,7 +469,7 @@
     <value>ProfileEditButton</value>
   </data>
   <data name="&gt;&gt;ProfileEditButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ProfileEditButton.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -445,10 +481,13 @@
     <value>True</value>
   </data>
   <data name="CastBloodSpells.Location" type="System.Drawing.Point, System.Drawing">
-    <value>277, 158</value>
+    <value>416, 243</value>
+  </data>
+  <data name="CastBloodSpells.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="CastBloodSpells.Size" type="System.Drawing.Size, System.Drawing">
-    <value>108, 17</value>
+    <value>160, 24</value>
   </data>
   <data name="CastBloodSpells.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -460,7 +499,7 @@
     <value>CastBloodSpells</value>
   </data>
   <data name="&gt;&gt;CastBloodSpells.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CastBloodSpells.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -469,10 +508,13 @@
     <value>1</value>
   </data>
   <data name="IronPillThreshold.Location" type="System.Drawing.Point, System.Drawing">
-    <value>277, 188</value>
+    <value>416, 289</value>
+  </data>
+  <data name="IronPillThreshold.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="IronPillThreshold.Size" type="System.Drawing.Size, System.Drawing">
-    <value>109, 20</value>
+    <value>164, 26</value>
   </data>
   <data name="IronPillThreshold.TabIndex" type="System.Int32, mscorlib">
     <value>26</value>
@@ -481,7 +523,7 @@
     <value>IronPillThreshold</value>
   </data>
   <data name="&gt;&gt;IronPillThreshold.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;IronPillThreshold.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -496,10 +538,13 @@
     <value>NoControl</value>
   </data>
   <data name="label123.Location" type="System.Drawing.Point, System.Drawing">
-    <value>225, 192</value>
+    <value>338, 295</value>
+  </data>
+  <data name="label123.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label123.Size" type="System.Drawing.Size, System.Drawing">
-    <value>41, 13</value>
+    <value>60, 20</value>
   </data>
   <data name="label123.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -511,7 +556,7 @@
     <value>label123</value>
   </data>
   <data name="&gt;&gt;label123.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label123.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -520,10 +565,13 @@
     <value>3</value>
   </data>
   <data name="GuffBThreshold.Location" type="System.Drawing.Point, System.Drawing">
-    <value>277, 250</value>
+    <value>416, 385</value>
+  </data>
+  <data name="GuffBThreshold.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="GuffBThreshold.Size" type="System.Drawing.Size, System.Drawing">
-    <value>109, 20</value>
+    <value>164, 26</value>
   </data>
   <data name="GuffBThreshold.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -532,7 +580,7 @@
     <value>GuffBThreshold</value>
   </data>
   <data name="&gt;&gt;GuffBThreshold.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GuffBThreshold.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -547,10 +595,13 @@
     <value>NoControl</value>
   </data>
   <data name="label26.Location" type="System.Drawing.Point, System.Drawing">
-    <value>229, 254</value>
+    <value>344, 391</value>
+  </data>
+  <data name="label26.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label26.Size" type="System.Drawing.Size, System.Drawing">
-    <value>37, 13</value>
+    <value>56, 20</value>
   </data>
   <data name="label26.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -562,7 +613,7 @@
     <value>label26</value>
   </data>
   <data name="&gt;&gt;label26.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label26.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -571,10 +622,13 @@
     <value>5</value>
   </data>
   <data name="GuffAThreshold.Location" type="System.Drawing.Point, System.Drawing">
-    <value>277, 220</value>
+    <value>416, 338</value>
+  </data>
+  <data name="GuffAThreshold.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="GuffAThreshold.Size" type="System.Drawing.Size, System.Drawing">
-    <value>109, 20</value>
+    <value>164, 26</value>
   </data>
   <data name="GuffAThreshold.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -583,7 +637,7 @@
     <value>GuffAThreshold</value>
   </data>
   <data name="&gt;&gt;GuffAThreshold.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GuffAThreshold.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -598,10 +652,13 @@
     <value>NoControl</value>
   </data>
   <data name="label27.Location" type="System.Drawing.Point, System.Drawing">
-    <value>229, 222</value>
+    <value>344, 342</value>
+  </data>
+  <data name="label27.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label27.Size" type="System.Drawing.Size, System.Drawing">
-    <value>37, 13</value>
+    <value>56, 20</value>
   </data>
   <data name="label27.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -613,7 +670,7 @@
     <value>label27</value>
   </data>
   <data name="&gt;&gt;label27.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label27.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -628,10 +685,13 @@
     <value>NoControl</value>
   </data>
   <data name="UpgradeDiggers.Location" type="System.Drawing.Point, System.Drawing">
-    <value>124, 89</value>
+    <value>186, 137</value>
+  </data>
+  <data name="UpgradeDiggers.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="UpgradeDiggers.Size" type="System.Drawing.Size, System.Drawing">
-    <value>131, 17</value>
+    <value>194, 24</value>
   </data>
   <data name="UpgradeDiggers.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -643,7 +703,7 @@
     <value>UpgradeDiggers</value>
   </data>
   <data name="&gt;&gt;UpgradeDiggers.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;UpgradeDiggers.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -658,10 +718,13 @@
     <value>NoControl</value>
   </data>
   <data name="ManageNGUDiff.Location" type="System.Drawing.Point, System.Drawing">
-    <value>124, 64</value>
+    <value>186, 98</value>
+  </data>
+  <data name="ManageNGUDiff.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ManageNGUDiff.Size" type="System.Drawing.Size, System.Drawing">
-    <value>135, 17</value>
+    <value>197, 24</value>
   </data>
   <data name="ManageNGUDiff.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -673,7 +736,7 @@
     <value>ManageNGUDiff</value>
   </data>
   <data name="&gt;&gt;ManageNGUDiff.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageNGUDiff.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -685,10 +748,13 @@
     <value>NoControl</value>
   </data>
   <data name="ChangeProfileFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>393, 13</value>
+    <value>590, 20</value>
+  </data>
+  <data name="ChangeProfileFile.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ChangeProfileFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 23</value>
+    <value>160, 35</value>
   </data>
   <data name="ChangeProfileFile.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -700,7 +766,7 @@
     <value>ChangeProfileFile</value>
   </data>
   <data name="&gt;&gt;ChangeProfileFile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ChangeProfileFile.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -715,10 +781,13 @@
     <value>NoControl</value>
   </data>
   <data name="AllocationProfileFileLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 17</value>
+    <value>24, 26</value>
+  </data>
+  <data name="AllocationProfileFileLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="AllocationProfileFileLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 13</value>
+    <value>126, 20</value>
   </data>
   <data name="AllocationProfileFileLabel.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -730,7 +799,7 @@
     <value>AllocationProfileFileLabel</value>
   </data>
   <data name="&gt;&gt;AllocationProfileFileLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AllocationProfileFileLabel.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -739,10 +808,13 @@
     <value>11</value>
   </data>
   <data name="AllocationProfileFile.Location" type="System.Drawing.Point, System.Drawing">
-    <value>124, 14</value>
+    <value>186, 22</value>
+  </data>
+  <data name="AllocationProfileFile.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="AllocationProfileFile.Size" type="System.Drawing.Size, System.Drawing">
-    <value>262, 21</value>
+    <value>391, 28</value>
   </data>
   <data name="AllocationProfileFile.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -751,7 +823,7 @@
     <value>AllocationProfileFile</value>
   </data>
   <data name="&gt;&gt;AllocationProfileFile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AllocationProfileFile.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -766,10 +838,13 @@
     <value>NoControl</value>
   </data>
   <data name="ManageR3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>228, 41</value>
+    <value>342, 63</value>
+  </data>
+  <data name="ManageR3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ManageR3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>82, 17</value>
+    <value>118, 24</value>
   </data>
   <data name="ManageR3.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -781,7 +856,7 @@
     <value>ManageR3</value>
   </data>
   <data name="&gt;&gt;ManageR3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageR3.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -790,10 +865,13 @@
     <value>13</value>
   </data>
   <data name="BloodNumberThreshold.Location" type="System.Drawing.Point, System.Drawing">
-    <value>96, 246</value>
+    <value>144, 378</value>
+  </data>
+  <data name="BloodNumberThreshold.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="BloodNumberThreshold.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 20</value>
+    <value>163, 26</value>
   </data>
   <data name="BloodNumberThreshold.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -802,7 +880,7 @@
     <value>BloodNumberThreshold</value>
   </data>
   <data name="&gt;&gt;BloodNumberThreshold.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BloodNumberThreshold.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -817,10 +895,13 @@
     <value>NoControl</value>
   </data>
   <data name="label18.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 249</value>
+    <value>21, 383</value>
+  </data>
+  <data name="label18.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label18.Size" type="System.Drawing.Size, System.Drawing">
-    <value>77, 13</value>
+    <value>115, 20</value>
   </data>
   <data name="label18.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -832,7 +913,7 @@
     <value>label18</value>
   </data>
   <data name="&gt;&gt;label18.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label18.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -844,10 +925,13 @@
     <value>NoControl</value>
   </data>
   <data name="SaveSpellCapButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>17, 286</value>
+    <value>26, 440</value>
+  </data>
+  <data name="SaveSpellCapButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="SaveSpellCapButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>112, 35</value>
   </data>
   <data name="SaveSpellCapButton.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -859,7 +943,7 @@
     <value>SaveSpellCapButton</value>
   </data>
   <data name="&gt;&gt;SaveSpellCapButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;SaveSpellCapButton.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -874,10 +958,13 @@
     <value>NoControl</value>
   </data>
   <data name="AutoSpellSwap.Location" type="System.Drawing.Point, System.Drawing">
-    <value>96, 158</value>
+    <value>144, 243</value>
+  </data>
+  <data name="AutoSpellSwap.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="AutoSpellSwap.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 17</value>
+    <value>176, 24</value>
   </data>
   <data name="AutoSpellSwap.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -889,7 +976,7 @@
     <value>AutoSpellSwap</value>
   </data>
   <data name="&gt;&gt;AutoSpellSwap.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoSpellSwap.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -901,10 +988,13 @@
     <value>NoControl</value>
   </data>
   <data name="label17.Location" type="System.Drawing.Point, System.Drawing">
-    <value>17, 178</value>
+    <value>26, 274</value>
+  </data>
+  <data name="label17.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label17.Size" type="System.Drawing.Size, System.Drawing">
-    <value>525, 1</value>
+    <value>786, 0</value>
   </data>
   <data name="label17.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -913,7 +1003,7 @@
     <value>label17</value>
   </data>
   <data name="&gt;&gt;label17.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label17.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -922,10 +1012,13 @@
     <value>18</value>
   </data>
   <data name="CounterfeitCap.Location" type="System.Drawing.Point, System.Drawing">
-    <value>96, 220</value>
+    <value>144, 338</value>
+  </data>
+  <data name="CounterfeitCap.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="CounterfeitCap.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 20</value>
+    <value>165, 26</value>
   </data>
   <data name="CounterfeitCap.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -934,7 +1027,7 @@
     <value>CounterfeitCap</value>
   </data>
   <data name="&gt;&gt;CounterfeitCap.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CounterfeitCap.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -949,10 +1042,13 @@
     <value>NoControl</value>
   </data>
   <data name="label16.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 222</value>
+    <value>24, 342</value>
+  </data>
+  <data name="label16.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label16.Size" type="System.Drawing.Size, System.Drawing">
-    <value>69, 13</value>
+    <value>106, 20</value>
   </data>
   <data name="label16.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -964,7 +1060,7 @@
     <value>label16</value>
   </data>
   <data name="&gt;&gt;label16.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label16.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -973,10 +1069,13 @@
     <value>20</value>
   </data>
   <data name="SpaghettiCap.Location" type="System.Drawing.Point, System.Drawing">
-    <value>96, 190</value>
+    <value>144, 292</value>
+  </data>
+  <data name="SpaghettiCap.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="SpaghettiCap.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 20</value>
+    <value>165, 26</value>
   </data>
   <data name="SpaghettiCap.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -985,7 +1084,7 @@
     <value>SpaghettiCap</value>
   </data>
   <data name="&gt;&gt;SpaghettiCap.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;SpaghettiCap.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -1000,10 +1099,13 @@
     <value>NoControl</value>
   </data>
   <data name="label15.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 192</value>
+    <value>24, 295</value>
+  </data>
+  <data name="label15.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label15.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 13</value>
+    <value>96, 20</value>
   </data>
   <data name="label15.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -1015,7 +1117,7 @@
     <value>label15</value>
   </data>
   <data name="&gt;&gt;label15.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label15.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -1030,10 +1132,13 @@
     <value>NoControl</value>
   </data>
   <data name="label14.Location" type="System.Drawing.Point, System.Drawing">
-    <value>14, 160</value>
+    <value>21, 246</value>
+  </data>
+  <data name="label14.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label14.Size" type="System.Drawing.Size, System.Drawing">
-    <value>35, 13</value>
+    <value>52, 20</value>
   </data>
   <data name="label14.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -1045,7 +1150,7 @@
     <value>label14</value>
   </data>
   <data name="&gt;&gt;label14.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label14.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -1060,10 +1165,13 @@
     <value>NoControl</value>
   </data>
   <data name="AutoRebirth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>17, 136</value>
+    <value>26, 209</value>
+  </data>
+  <data name="AutoRebirth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="AutoRebirth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 17</value>
+    <value>125, 24</value>
   </data>
   <data name="AutoRebirth.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1075,7 +1183,7 @@
     <value>AutoRebirth</value>
   </data>
   <data name="&gt;&gt;AutoRebirth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoRebirth.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -1090,10 +1198,13 @@
     <value>NoControl</value>
   </data>
   <data name="ManageWandoos.Location" type="System.Drawing.Point, System.Drawing">
-    <value>17, 112</value>
+    <value>26, 172</value>
+  </data>
+  <data name="ManageWandoos.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ManageWandoos.Size" type="System.Drawing.Size, System.Drawing">
-    <value>132, 17</value>
+    <value>192, 24</value>
   </data>
   <data name="ManageWandoos.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1105,7 +1216,7 @@
     <value>ManageWandoos</value>
   </data>
   <data name="&gt;&gt;ManageWandoos.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageWandoos.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -1120,10 +1231,13 @@
     <value>NoControl</value>
   </data>
   <data name="ManageDiggers.Location" type="System.Drawing.Point, System.Drawing">
-    <value>17, 88</value>
+    <value>26, 135</value>
+  </data>
+  <data name="ManageDiggers.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ManageDiggers.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 17</value>
+    <value>152, 24</value>
   </data>
   <data name="ManageDiggers.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1135,7 +1249,7 @@
     <value>ManageDiggers</value>
   </data>
   <data name="&gt;&gt;ManageDiggers.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageDiggers.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -1150,10 +1264,13 @@
     <value>NoControl</value>
   </data>
   <data name="ManageGear.Location" type="System.Drawing.Point, System.Drawing">
-    <value>17, 64</value>
+    <value>26, 98</value>
+  </data>
+  <data name="ManageGear.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ManageGear.Size" type="System.Drawing.Size, System.Drawing">
-    <value>91, 17</value>
+    <value>133, 24</value>
   </data>
   <data name="ManageGear.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -1165,7 +1282,7 @@
     <value>ManageGear</value>
   </data>
   <data name="&gt;&gt;ManageGear.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageGear.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -1180,10 +1297,13 @@
     <value>NoControl</value>
   </data>
   <data name="ManageMagic.Location" type="System.Drawing.Point, System.Drawing">
-    <value>124, 41</value>
+    <value>186, 63</value>
+  </data>
+  <data name="ManageMagic.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ManageMagic.Size" type="System.Drawing.Size, System.Drawing">
-    <value>97, 17</value>
+    <value>139, 24</value>
   </data>
   <data name="ManageMagic.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1195,7 +1315,7 @@
     <value>ManageMagic</value>
   </data>
   <data name="&gt;&gt;ManageMagic.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageMagic.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -1210,10 +1330,13 @@
     <value>NoControl</value>
   </data>
   <data name="ManageEnergy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>17, 41</value>
+    <value>26, 63</value>
+  </data>
+  <data name="ManageEnergy.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ManageEnergy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 17</value>
+    <value>147, 24</value>
   </data>
   <data name="ManageEnergy.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1225,7 +1348,7 @@
     <value>ManageEnergy</value>
   </data>
   <data name="&gt;&gt;ManageEnergy.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageEnergy.Parent" xml:space="preserve">
     <value>tabPage2</value>
@@ -1234,13 +1357,16 @@
     <value>29</value>
   </data>
   <data name="tabPage2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="tabPage2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>590, 334</value>
+    <value>889, 521</value>
   </data>
   <data name="tabPage2.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1252,7 +1378,7 @@
     <value>tabPage2</value>
   </data>
   <data name="&gt;&gt;tabPage2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage2.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -1261,10 +1387,13 @@
     <value>1</value>
   </data>
   <data name="YggSwapThreshold.Location" type="System.Drawing.Point, System.Drawing">
-    <value>316, 29</value>
+    <value>474, 45</value>
+  </data>
+  <data name="YggSwapThreshold.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="YggSwapThreshold.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
+    <value>180, 26</value>
   </data>
   <data name="YggSwapThreshold.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -1273,7 +1402,7 @@
     <value>YggSwapThreshold</value>
   </data>
   <data name="&gt;&gt;YggSwapThreshold.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;YggSwapThreshold.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1285,10 +1414,13 @@
     <value>True</value>
   </data>
   <data name="label28.Location" type="System.Drawing.Point, System.Drawing">
-    <value>165, 30</value>
+    <value>248, 46</value>
+  </data>
+  <data name="label28.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label28.Size" type="System.Drawing.Size, System.Drawing">
-    <value>145, 13</value>
+    <value>216, 20</value>
   </data>
   <data name="label28.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -1300,7 +1432,7 @@
     <value>label28</value>
   </data>
   <data name="&gt;&gt;label28.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label28.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1315,10 +1447,13 @@
     <value>NoControl</value>
   </data>
   <data name="HarvestSafety.Location" type="System.Drawing.Point, System.Drawing">
-    <value>462, 310</value>
+    <value>693, 477</value>
+  </data>
+  <data name="HarvestSafety.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="HarvestSafety.Size" type="System.Drawing.Size, System.Drawing">
-    <value>15, 14</value>
+    <value>22, 21</value>
   </data>
   <data name="HarvestSafety.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -1327,7 +1462,7 @@
     <value>HarvestSafety</value>
   </data>
   <data name="&gt;&gt;HarvestSafety.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;HarvestSafety.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1342,10 +1477,13 @@
     <value>NoControl</value>
   </data>
   <data name="HarvestAllButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>483, 305</value>
+    <value>724, 469</value>
+  </data>
+  <data name="HarvestAllButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="HarvestAllButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 23</value>
+    <value>152, 35</value>
   </data>
   <data name="HarvestAllButton.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -1357,7 +1495,7 @@
     <value>HarvestAllButton</value>
   </data>
   <data name="&gt;&gt;HarvestAllButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;HarvestAllButton.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1372,10 +1510,13 @@
     <value>NoControl</value>
   </data>
   <data name="ActivateFruits.Location" type="System.Drawing.Point, System.Drawing">
-    <value>120, 6</value>
+    <value>180, 9</value>
+  </data>
+  <data name="ActivateFruits.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ActivateFruits.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 17</value>
+    <value>136, 24</value>
   </data>
   <data name="ActivateFruits.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -1387,7 +1528,7 @@
     <value>ActivateFruits</value>
   </data>
   <data name="&gt;&gt;ActivateFruits.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ActivateFruits.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1405,10 +1546,13 @@
     <value>NoControl</value>
   </data>
   <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 55</value>
+    <value>6, 85</value>
+  </data>
+  <data name="label3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 16</value>
+    <value>83, 25</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -1420,7 +1564,7 @@
     <value>label3</value>
   </data>
   <data name="&gt;&gt;label3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label3.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1435,10 +1579,13 @@
     <value>NoControl</value>
   </data>
   <data name="yggRemoveButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>233, 149</value>
+    <value>350, 229</value>
+  </data>
+  <data name="yggRemoveButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="yggRemoveButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 23</value>
+    <value>171, 46</value>
   </data>
   <data name="yggRemoveButton.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -1450,7 +1597,7 @@
     <value>yggRemoveButton</value>
   </data>
   <data name="&gt;&gt;yggRemoveButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;yggRemoveButton.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1459,10 +1606,13 @@
     <value>6</value>
   </data>
   <data name="yggLoadoutItem.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 252</value>
+    <value>12, 388</value>
+  </data>
+  <data name="yggLoadoutItem.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="yggLoadoutItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>205, 20</value>
+    <value>308, 26</value>
   </data>
   <data name="yggLoadoutItem.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -1471,7 +1621,7 @@
     <value>yggLoadoutItem</value>
   </data>
   <data name="&gt;&gt;yggLoadoutItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;yggLoadoutItem.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1486,10 +1636,13 @@
     <value>NoControl</value>
   </data>
   <data name="yggItemLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 275</value>
+    <value>10, 423</value>
+  </data>
+  <data name="yggItemLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="yggItemLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 13</value>
+    <value>20, 20</value>
   </data>
   <data name="yggItemLabel.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -1501,7 +1654,7 @@
     <value>yggItemLabel</value>
   </data>
   <data name="&gt;&gt;yggItemLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;yggItemLabel.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1513,10 +1666,13 @@
     <value>NoControl</value>
   </data>
   <data name="yggAddButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>233, 252</value>
+    <value>350, 388</value>
+  </data>
+  <data name="yggAddButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="yggAddButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>112, 31</value>
   </data>
   <data name="yggAddButton.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -1528,13 +1684,16 @@
     <value>yggAddButton</value>
   </data>
   <data name="&gt;&gt;yggAddButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;yggAddButton.Parent" xml:space="preserve">
     <value>tabPage3</value>
   </data>
   <data name="&gt;&gt;yggAddButton.ZOrder" xml:space="preserve">
     <value>9</value>
+  </data>
+  <data name="yggdrasilLoadoutBox.ItemHeight" type="System.Int32, mscorlib">
+    <value>20</value>
   </data>
   <data name="yggdrasilLoadoutBox.Items" xml:space="preserve">
     <value>test</value>
@@ -1543,10 +1702,13 @@
     <value>test2</value>
   </data>
   <data name="yggdrasilLoadoutBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 85</value>
+    <value>10, 131</value>
+  </data>
+  <data name="yggdrasilLoadoutBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="yggdrasilLoadoutBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>206, 160</value>
+    <value>307, 244</value>
   </data>
   <data name="yggdrasilLoadoutBox.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -1555,7 +1717,7 @@
     <value>yggdrasilLoadoutBox</value>
   </data>
   <data name="&gt;&gt;yggdrasilLoadoutBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;yggdrasilLoadoutBox.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1570,10 +1732,13 @@
     <value>NoControl</value>
   </data>
   <data name="YggdrasilSwap.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 29</value>
+    <value>4, 45</value>
+  </data>
+  <data name="YggdrasilSwap.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="YggdrasilSwap.Size" type="System.Drawing.Size, System.Drawing">
-    <value>156, 17</value>
+    <value>231, 24</value>
   </data>
   <data name="YggdrasilSwap.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1585,7 +1750,7 @@
     <value>YggdrasilSwap</value>
   </data>
   <data name="&gt;&gt;YggdrasilSwap.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;YggdrasilSwap.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1600,10 +1765,13 @@
     <value>NoControl</value>
   </data>
   <data name="ManageYggdrasil.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 6</value>
+    <value>4, 9</value>
+  </data>
+  <data name="ManageYggdrasil.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ManageYggdrasil.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 17</value>
+    <value>163, 24</value>
   </data>
   <data name="ManageYggdrasil.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1615,7 +1783,7 @@
     <value>ManageYggdrasil</value>
   </data>
   <data name="&gt;&gt;ManageYggdrasil.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageYggdrasil.Parent" xml:space="preserve">
     <value>tabPage3</value>
@@ -1624,13 +1792,16 @@
     <value>12</value>
   </data>
   <data name="tabPage3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="tabPage3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage3.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>590, 334</value>
+    <value>889, 521</value>
   </data>
   <data name="tabPage3.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -1642,7 +1813,7 @@
     <value>tabPage3</value>
   </data>
   <data name="&gt;&gt;tabPage3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage3.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -1651,10 +1822,13 @@
     <value>2</value>
   </data>
   <data name="BoostAvgReset.Location" type="System.Drawing.Point, System.Drawing">
-    <value>463, 6</value>
+    <value>694, 9</value>
+  </data>
+  <data name="BoostAvgReset.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="BoostAvgReset.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 23</value>
+    <value>182, 35</value>
   </data>
   <data name="BoostAvgReset.TabIndex" type="System.Int32, mscorlib">
     <value>35</value>
@@ -1666,7 +1840,7 @@
     <value>BoostAvgReset</value>
   </data>
   <data name="&gt;&gt;BoostAvgReset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BoostAvgReset.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1675,10 +1849,13 @@
     <value>0</value>
   </data>
   <data name="CubePriority.Location" type="System.Drawing.Point, System.Drawing">
-    <value>76, 50</value>
+    <value>114, 77</value>
+  </data>
+  <data name="CubePriority.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="CubePriority.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+    <value>180, 28</value>
   </data>
   <data name="CubePriority.TabIndex" type="System.Int32, mscorlib">
     <value>34</value>
@@ -1687,7 +1864,7 @@
     <value>CubePriority</value>
   </data>
   <data name="&gt;&gt;CubePriority.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CubePriority.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1702,10 +1879,13 @@
     <value>NoControl</value>
   </data>
   <data name="label20.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 53</value>
+    <value>6, 82</value>
+  </data>
+  <data name="label20.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label20.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 13</value>
+    <value>98, 20</value>
   </data>
   <data name="label20.TabIndex" type="System.Int32, mscorlib">
     <value>33</value>
@@ -1717,7 +1897,7 @@
     <value>label20</value>
   </data>
   <data name="&gt;&gt;label20.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label20.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1732,10 +1912,13 @@
     <value>NoControl</value>
   </data>
   <data name="prioDownButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>230, 206</value>
+    <value>345, 317</value>
+  </data>
+  <data name="prioDownButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="prioDownButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 23</value>
+    <value>39, 46</value>
   </data>
   <data name="prioDownButton.TabIndex" type="System.Int32, mscorlib">
     <value>32</value>
@@ -1747,7 +1930,7 @@
     <value>prioDownButton</value>
   </data>
   <data name="&gt;&gt;prioDownButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;prioDownButton.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1762,10 +1945,13 @@
     <value>NoControl</value>
   </data>
   <data name="prioUpButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>230, 148</value>
+    <value>345, 228</value>
+  </data>
+  <data name="prioUpButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="prioUpButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 23</value>
+    <value>39, 46</value>
   </data>
   <data name="prioUpButton.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -1777,7 +1963,7 @@
     <value>prioUpButton</value>
   </data>
   <data name="&gt;&gt;prioUpButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;prioUpButton.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1795,10 +1981,13 @@
     <value>NoControl</value>
   </data>
   <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>299, 85</value>
+    <value>448, 131</value>
+  </data>
+  <data name="label5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>109, 16</value>
+    <value>157, 25</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -1810,7 +1999,7 @@
     <value>label5</value>
   </data>
   <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label5.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1825,10 +2014,13 @@
     <value>NoControl</value>
   </data>
   <data name="blacklistRemove.Location" type="System.Drawing.Point, System.Drawing">
-    <value>496, 177</value>
+    <value>744, 272</value>
+  </data>
+  <data name="blacklistRemove.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="blacklistRemove.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 23</value>
+    <value>171, 46</value>
   </data>
   <data name="blacklistRemove.TabIndex" type="System.Int32, mscorlib">
     <value>29</value>
@@ -1840,7 +2032,7 @@
     <value>blacklistRemove</value>
   </data>
   <data name="&gt;&gt;blacklistRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;blacklistRemove.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1849,10 +2041,13 @@
     <value>6</value>
   </data>
   <data name="blacklistAddItem.Location" type="System.Drawing.Point, System.Drawing">
-    <value>303, 280</value>
+    <value>454, 431</value>
+  </data>
+  <data name="blacklistAddItem.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="blacklistAddItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>173, 20</value>
+    <value>260, 26</value>
   </data>
   <data name="blacklistAddItem.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
@@ -1861,7 +2056,7 @@
     <value>blacklistAddItem</value>
   </data>
   <data name="&gt;&gt;blacklistAddItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;blacklistAddItem.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1876,10 +2071,13 @@
     <value>NoControl</value>
   </data>
   <data name="blacklistLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>300, 303</value>
+    <value>450, 466</value>
+  </data>
+  <data name="blacklistLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="blacklistLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 13</value>
+    <value>20, 20</value>
   </data>
   <data name="blacklistLabel.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -1891,7 +2089,7 @@
     <value>blacklistLabel</value>
   </data>
   <data name="&gt;&gt;blacklistLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;blacklistLabel.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1903,10 +2101,13 @@
     <value>NoControl</value>
   </data>
   <data name="blacklistAdd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>496, 280</value>
+    <value>744, 431</value>
+  </data>
+  <data name="blacklistAdd.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="blacklistAdd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>112, 31</value>
   </data>
   <data name="blacklistAdd.TabIndex" type="System.Int32, mscorlib">
     <value>26</value>
@@ -1918,13 +2119,16 @@
     <value>blacklistAdd</value>
   </data>
   <data name="&gt;&gt;blacklistAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;blacklistAdd.Parent" xml:space="preserve">
     <value>tabPage4</value>
   </data>
   <data name="&gt;&gt;blacklistAdd.ZOrder" xml:space="preserve">
     <value>9</value>
+  </data>
+  <data name="blacklistBox.ItemHeight" type="System.Int32, mscorlib">
+    <value>20</value>
   </data>
   <data name="blacklistBox.Items" xml:space="preserve">
     <value>test</value>
@@ -1933,10 +2137,13 @@
     <value>test2</value>
   </data>
   <data name="blacklistBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>302, 113</value>
+    <value>453, 174</value>
+  </data>
+  <data name="blacklistBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="blacklistBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>174, 160</value>
+    <value>259, 244</value>
   </data>
   <data name="blacklistBox.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -1945,7 +2152,7 @@
     <value>blacklistBox</value>
   </data>
   <data name="&gt;&gt;blacklistBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;blacklistBox.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1963,10 +2170,13 @@
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 85</value>
+    <value>9, 131</value>
+  </data>
+  <data name="label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 16</value>
+    <value>136, 25</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -1978,7 +2188,7 @@
     <value>label2</value>
   </data>
   <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label2.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -1993,10 +2203,13 @@
     <value>NoControl</value>
   </data>
   <data name="priorityBoostRemove.Location" type="System.Drawing.Point, System.Drawing">
-    <value>203, 177</value>
+    <value>304, 272</value>
+  </data>
+  <data name="priorityBoostRemove.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="priorityBoostRemove.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 23</value>
+    <value>171, 46</value>
   </data>
   <data name="priorityBoostRemove.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -2008,7 +2221,7 @@
     <value>priorityBoostRemove</value>
   </data>
   <data name="&gt;&gt;priorityBoostRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;priorityBoostRemove.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -2017,10 +2230,13 @@
     <value>12</value>
   </data>
   <data name="priorityBoostItemAdd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 280</value>
+    <value>15, 431</value>
+  </data>
+  <data name="priorityBoostItemAdd.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="priorityBoostItemAdd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>176, 20</value>
+    <value>264, 26</value>
   </data>
   <data name="priorityBoostItemAdd.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -2029,7 +2245,7 @@
     <value>priorityBoostItemAdd</value>
   </data>
   <data name="&gt;&gt;priorityBoostItemAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;priorityBoostItemAdd.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -2044,10 +2260,13 @@
     <value>NoControl</value>
   </data>
   <data name="priorityBoostLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 303</value>
+    <value>10, 466</value>
+  </data>
+  <data name="priorityBoostLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="priorityBoostLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 13</value>
+    <value>20, 20</value>
   </data>
   <data name="priorityBoostLabel.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -2059,7 +2278,7 @@
     <value>priorityBoostLabel</value>
   </data>
   <data name="&gt;&gt;priorityBoostLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;priorityBoostLabel.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -2071,10 +2290,13 @@
     <value>NoControl</value>
   </data>
   <data name="priorityBoostAdd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>203, 280</value>
+    <value>304, 431</value>
+  </data>
+  <data name="priorityBoostAdd.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="priorityBoostAdd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>112, 31</value>
   </data>
   <data name="priorityBoostAdd.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -2086,13 +2308,16 @@
     <value>priorityBoostAdd</value>
   </data>
   <data name="&gt;&gt;priorityBoostAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;priorityBoostAdd.Parent" xml:space="preserve">
     <value>tabPage4</value>
   </data>
   <data name="&gt;&gt;priorityBoostAdd.ZOrder" xml:space="preserve">
     <value>15</value>
+  </data>
+  <data name="priorityBoostBox.ItemHeight" type="System.Int32, mscorlib">
+    <value>20</value>
   </data>
   <data name="priorityBoostBox.Items" xml:space="preserve">
     <value>test</value>
@@ -2101,10 +2326,13 @@
     <value>test2</value>
   </data>
   <data name="priorityBoostBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 113</value>
+    <value>14, 174</value>
+  </data>
+  <data name="priorityBoostBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="priorityBoostBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 160</value>
+    <value>264, 244</value>
   </data>
   <data name="priorityBoostBox.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -2113,7 +2341,7 @@
     <value>priorityBoostBox</value>
   </data>
   <data name="&gt;&gt;priorityBoostBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;priorityBoostBox.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -2128,10 +2356,13 @@
     <value>NoControl</value>
   </data>
   <data name="ManageInventory.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 6</value>
+    <value>4, 9</value>
+  </data>
+  <data name="ManageInventory.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ManageInventory.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 17</value>
+    <value>162, 24</value>
   </data>
   <data name="ManageInventory.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -2143,7 +2374,7 @@
     <value>ManageInventory</value>
   </data>
   <data name="&gt;&gt;ManageInventory.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageInventory.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -2158,10 +2389,13 @@
     <value>NoControl</value>
   </data>
   <data name="ManageBoostConvert.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 29</value>
+    <value>4, 45</value>
+  </data>
+  <data name="ManageBoostConvert.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ManageBoostConvert.Size" type="System.Drawing.Size, System.Drawing">
-    <value>151, 17</value>
+    <value>222, 24</value>
   </data>
   <data name="ManageBoostConvert.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -2173,7 +2407,7 @@
     <value>ManageBoostConvert</value>
   </data>
   <data name="&gt;&gt;ManageBoostConvert.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageBoostConvert.Parent" xml:space="preserve">
     <value>tabPage4</value>
@@ -2182,13 +2416,16 @@
     <value>18</value>
   </data>
   <data name="tabPage4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="tabPage4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage4.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>590, 334</value>
+    <value>889, 521</value>
   </data>
   <data name="tabPage4.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -2200,7 +2437,7 @@
     <value>tabPage4</value>
   </data>
   <data name="&gt;&gt;tabPage4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage4.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -2218,10 +2455,13 @@
     <value>NoControl</value>
   </data>
   <data name="label9.Location" type="System.Drawing.Point, System.Drawing">
-    <value>362, 36</value>
+    <value>543, 55</value>
+  </data>
+  <data name="label9.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 16</value>
+    <value>176, 25</value>
   </data>
   <data name="label9.TabIndex" type="System.Int32, mscorlib">
     <value>34</value>
@@ -2233,7 +2473,7 @@
     <value>label9</value>
   </data>
   <data name="&gt;&gt;label9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label9.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2248,10 +2488,13 @@
     <value>203</value>
   </data>
   <data name="TitanSwapTargets.Location" type="System.Drawing.Point, System.Drawing">
-    <value>365, 64</value>
+    <value>548, 98</value>
+  </data>
+  <data name="TitanSwapTargets.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="TitanSwapTargets.Size" type="System.Drawing.Size, System.Drawing">
-    <value>208, 186</value>
+    <value>310, 284</value>
   </data>
   <data name="TitanSwapTargets.TabIndex" type="System.Int32, mscorlib">
     <value>33</value>
@@ -2260,7 +2503,7 @@
     <value>TitanSwapTargets</value>
   </data>
   <data name="&gt;&gt;TitanSwapTargets.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TitanSwapTargets.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2278,10 +2521,13 @@
     <value>NoControl</value>
   </data>
   <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 36</value>
+    <value>9, 55</value>
+  </data>
+  <data name="label8.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 16</value>
+    <value>83, 25</value>
   </data>
   <data name="label8.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -2293,7 +2539,7 @@
     <value>label8</value>
   </data>
   <data name="&gt;&gt;label8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label8.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2308,10 +2554,13 @@
     <value>NoControl</value>
   </data>
   <data name="titanRemove.Location" type="System.Drawing.Point, System.Drawing">
-    <value>267, 127</value>
+    <value>400, 195</value>
+  </data>
+  <data name="titanRemove.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="titanRemove.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 23</value>
+    <value>171, 46</value>
   </data>
   <data name="titanRemove.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -2323,7 +2572,7 @@
     <value>titanRemove</value>
   </data>
   <data name="&gt;&gt;titanRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;titanRemove.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2332,10 +2581,13 @@
     <value>3</value>
   </data>
   <data name="titanAddItem.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 231</value>
+    <value>15, 355</value>
+  </data>
+  <data name="titanAddItem.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="titanAddItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>251, 20</value>
+    <value>376, 26</value>
   </data>
   <data name="titanAddItem.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -2344,7 +2596,7 @@
     <value>titanAddItem</value>
   </data>
   <data name="&gt;&gt;titanAddItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;titanAddItem.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2359,10 +2611,13 @@
     <value>NoControl</value>
   </data>
   <data name="titanLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 254</value>
+    <value>14, 391</value>
+  </data>
+  <data name="titanLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="titanLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 13</value>
+    <value>20, 20</value>
   </data>
   <data name="titanLabel.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -2374,7 +2629,7 @@
     <value>titanLabel</value>
   </data>
   <data name="&gt;&gt;titanLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;titanLabel.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2386,10 +2641,13 @@
     <value>NoControl</value>
   </data>
   <data name="titanAdd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>267, 230</value>
+    <value>400, 354</value>
+  </data>
+  <data name="titanAdd.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="titanAdd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>112, 31</value>
   </data>
   <data name="titanAdd.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -2401,13 +2659,16 @@
     <value>titanAdd</value>
   </data>
   <data name="&gt;&gt;titanAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;titanAdd.Parent" xml:space="preserve">
     <value>tabPage5</value>
   </data>
   <data name="&gt;&gt;titanAdd.ZOrder" xml:space="preserve">
     <value>6</value>
+  </data>
+  <data name="titanLoadout.ItemHeight" type="System.Int32, mscorlib">
+    <value>20</value>
   </data>
   <data name="titanLoadout.Items" xml:space="preserve">
     <value>test</value>
@@ -2416,10 +2677,13 @@
     <value>test2</value>
   </data>
   <data name="titanLoadout.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 64</value>
+    <value>14, 98</value>
+  </data>
+  <data name="titanLoadout.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="titanLoadout.Size" type="System.Drawing.Size, System.Drawing">
-    <value>252, 160</value>
+    <value>376, 244</value>
   </data>
   <data name="titanLoadout.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -2428,7 +2692,7 @@
     <value>titanLoadout</value>
   </data>
   <data name="&gt;&gt;titanLoadout.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;titanLoadout.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2443,10 +2707,13 @@
     <value>NoControl</value>
   </data>
   <data name="SwapTitanLoadout.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 7</value>
+    <value>10, 11</value>
+  </data>
+  <data name="SwapTitanLoadout.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="SwapTitanLoadout.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 17</value>
+    <value>208, 24</value>
   </data>
   <data name="SwapTitanLoadout.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -2458,7 +2725,7 @@
     <value>SwapTitanLoadout</value>
   </data>
   <data name="&gt;&gt;SwapTitanLoadout.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;SwapTitanLoadout.Parent" xml:space="preserve">
     <value>tabPage5</value>
@@ -2467,13 +2734,16 @@
     <value>8</value>
   </data>
   <data name="tabPage5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="tabPage5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage5.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>590, 334</value>
+    <value>889, 521</value>
   </data>
   <data name="tabPage5.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -2485,7 +2755,7 @@
     <value>tabPage5</value>
   </data>
   <data name="&gt;&gt;tabPage5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage5.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -2497,10 +2767,13 @@
     <value>NoControl</value>
   </data>
   <data name="label32.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 206</value>
+    <value>6, 317</value>
+  </data>
+  <data name="label32.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label32.Size" type="System.Drawing.Size, System.Drawing">
-    <value>525, 1</value>
+    <value>786, 0</value>
   </data>
   <data name="label32.TabIndex" type="System.Int32, mscorlib">
     <value>33</value>
@@ -2509,7 +2782,7 @@
     <value>label32</value>
   </data>
   <data name="&gt;&gt;label32.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label32.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2524,10 +2797,13 @@
     <value>NoControl</value>
   </data>
   <data name="BlacklistAddEnemyButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>440, 242</value>
+    <value>660, 372</value>
+  </data>
+  <data name="BlacklistAddEnemyButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="BlacklistAddEnemyButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 23</value>
+    <value>152, 46</value>
   </data>
   <data name="BlacklistAddEnemyButton.TabIndex" type="System.Int32, mscorlib">
     <value>32</value>
@@ -2539,7 +2815,7 @@
     <value>BlacklistAddEnemyButton</value>
   </data>
   <data name="&gt;&gt;BlacklistAddEnemyButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BlacklistAddEnemyButton.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2554,10 +2830,13 @@
     <value>NoControl</value>
   </data>
   <data name="label31.Location" type="System.Drawing.Point, System.Drawing">
-    <value>200, 247</value>
+    <value>300, 380</value>
+  </data>
+  <data name="label31.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label31.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+    <value>71, 20</value>
   </data>
   <data name="label31.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -2569,7 +2848,7 @@
     <value>label31</value>
   </data>
   <data name="&gt;&gt;label31.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label31.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2578,10 +2857,13 @@
     <value>2</value>
   </data>
   <data name="EnemyBlacklistNames.Location" type="System.Drawing.Point, System.Drawing">
-    <value>265, 244</value>
+    <value>398, 375</value>
+  </data>
+  <data name="EnemyBlacklistNames.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="EnemyBlacklistNames.Size" type="System.Drawing.Size, System.Drawing">
-    <value>169, 21</value>
+    <value>252, 28</value>
   </data>
   <data name="EnemyBlacklistNames.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -2590,7 +2872,7 @@
     <value>EnemyBlacklistNames</value>
   </data>
   <data name="&gt;&gt;EnemyBlacklistNames.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;EnemyBlacklistNames.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2602,10 +2884,13 @@
     <value>True</value>
   </data>
   <data name="label30.Location" type="System.Drawing.Point, System.Drawing">
-    <value>200, 220</value>
+    <value>300, 338</value>
+  </data>
+  <data name="label30.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label30.Size" type="System.Drawing.Size, System.Drawing">
-    <value>32, 13</value>
+    <value>46, 20</value>
   </data>
   <data name="label30.TabIndex" type="System.Int32, mscorlib">
     <value>29</value>
@@ -2617,7 +2902,7 @@
     <value>label30</value>
   </data>
   <data name="&gt;&gt;label30.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label30.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2632,10 +2917,13 @@
     <value>NoControl</value>
   </data>
   <data name="BlacklistRemoveEnemyButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>203, 305</value>
+    <value>304, 469</value>
+  </data>
+  <data name="BlacklistRemoveEnemyButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="BlacklistRemoveEnemyButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>92, 23</value>
+    <value>196, 46</value>
   </data>
   <data name="BlacklistRemoveEnemyButton.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
@@ -2647,7 +2935,7 @@
     <value>BlacklistRemoveEnemyButton</value>
   </data>
   <data name="&gt;&gt;BlacklistRemoveEnemyButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BlacklistRemoveEnemyButton.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2656,10 +2944,13 @@
     <value>5</value>
   </data>
   <data name="EnemyBlacklistZone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>265, 217</value>
+    <value>398, 334</value>
+  </data>
+  <data name="EnemyBlacklistZone.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="EnemyBlacklistZone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>169, 21</value>
+    <value>252, 28</value>
   </data>
   <data name="EnemyBlacklistZone.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -2668,7 +2959,7 @@
     <value>EnemyBlacklistZone</value>
   </data>
   <data name="&gt;&gt;EnemyBlacklistZone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;EnemyBlacklistZone.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2680,10 +2971,13 @@
     <value>True</value>
   </data>
   <data name="label29.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 191</value>
+    <value>8, 294</value>
+  </data>
+  <data name="label29.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label29.Size" type="System.Drawing.Size, System.Drawing">
-    <value>101, 13</value>
+    <value>151, 20</value>
   </data>
   <data name="label29.TabIndex" type="System.Int32, mscorlib">
     <value>26</value>
@@ -2695,7 +2989,7 @@
     <value>label29</value>
   </data>
   <data name="&gt;&gt;label29.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label29.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2703,11 +2997,17 @@
   <data name="&gt;&gt;label29.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
+  <data name="BlacklistedBosses.ItemHeight" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
   <data name="BlacklistedBosses.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 220</value>
+    <value>9, 338</value>
+  </data>
+  <data name="BlacklistedBosses.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="BlacklistedBosses.Size" type="System.Drawing.Size, System.Drawing">
-    <value>182, 108</value>
+    <value>271, 164</value>
   </data>
   <data name="BlacklistedBosses.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -2716,7 +3016,7 @@
     <value>BlacklistedBosses</value>
   </data>
   <data name="&gt;&gt;BlacklistedBosses.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BlacklistedBosses.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2728,10 +3028,13 @@
     <value>True</value>
   </data>
   <data name="MoreBlockParry.Location" type="System.Drawing.Point, System.Drawing">
-    <value>371, 30</value>
+    <value>556, 46</value>
+  </data>
+  <data name="MoreBlockParry.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="MoreBlockParry.Size" type="System.Drawing.Size, System.Drawing">
-    <value>131, 17</value>
+    <value>188, 24</value>
   </data>
   <data name="MoreBlockParry.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -2743,7 +3046,7 @@
     <value>MoreBlockParry</value>
   </data>
   <data name="&gt;&gt;MoreBlockParry.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MoreBlockParry.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2758,10 +3061,13 @@
     <value>NoControl</value>
   </data>
   <data name="ITOPODBeastMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>291, 167</value>
+    <value>436, 257</value>
+  </data>
+  <data name="ITOPODBeastMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ITOPODBeastMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 17</value>
+    <value>121, 24</value>
   </data>
   <data name="ITOPODBeastMode.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -2773,7 +3079,7 @@
     <value>ITOPODBeastMode</value>
   </data>
   <data name="&gt;&gt;ITOPODBeastMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ITOPODBeastMode.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2788,10 +3094,13 @@
     <value>NoControl</value>
   </data>
   <data name="ITOPODRecoverHP.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 167</value>
+    <value>162, 257</value>
+  </data>
+  <data name="ITOPODRecoverHP.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ITOPODRecoverHP.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 17</value>
+    <value>120, 24</value>
   </data>
   <data name="ITOPODRecoverHP.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -2803,7 +3112,7 @@
     <value>ITOPODRecoverHP</value>
   </data>
   <data name="&gt;&gt;ITOPODRecoverHP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ITOPODRecoverHP.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2818,10 +3127,13 @@
     <value>NoControl</value>
   </data>
   <data name="ITOPODFastCombat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>199, 167</value>
+    <value>298, 257</value>
+  </data>
+  <data name="ITOPODFastCombat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ITOPODFastCombat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 17</value>
+    <value>127, 24</value>
   </data>
   <data name="ITOPODFastCombat.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -2833,7 +3145,7 @@
     <value>ITOPODFastCombat</value>
   </data>
   <data name="&gt;&gt;ITOPODFastCombat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ITOPODFastCombat.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2848,10 +3160,13 @@
     <value>NoControl</value>
   </data>
   <data name="ITOPODPrecastBuffs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 167</value>
+    <value>9, 257</value>
+  </data>
+  <data name="ITOPODPrecastBuffs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ITOPODPrecastBuffs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 17</value>
+    <value>131, 24</value>
   </data>
   <data name="ITOPODPrecastBuffs.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -2863,7 +3178,7 @@
     <value>ITOPODPrecastBuffs</value>
   </data>
   <data name="&gt;&gt;ITOPODPrecastBuffs.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ITOPODPrecastBuffs.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2878,10 +3193,13 @@
     <value>NoControl</value>
   </data>
   <data name="label24.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 139</value>
+    <value>4, 214</value>
+  </data>
+  <data name="label24.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label24.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 13</value>
+    <value>109, 20</value>
   </data>
   <data name="label24.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -2893,7 +3211,7 @@
     <value>label24</value>
   </data>
   <data name="&gt;&gt;label24.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label24.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2908,10 +3226,13 @@
     <value>Manual</value>
   </data>
   <data name="ITOPODCombatMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>104, 136</value>
+    <value>156, 209</value>
+  </data>
+  <data name="ITOPODCombatMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ITOPODCombatMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+    <value>180, 28</value>
   </data>
   <data name="ITOPODCombatMode.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -2920,7 +3241,7 @@
     <value>ITOPODCombatMode</value>
   </data>
   <data name="&gt;&gt;ITOPODCombatMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ITOPODCombatMode.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2932,10 +3253,13 @@
     <value>NoControl</value>
   </data>
   <data name="label22.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 128</value>
+    <value>9, 197</value>
+  </data>
+  <data name="label22.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label22.Size" type="System.Drawing.Size, System.Drawing">
-    <value>525, 1</value>
+    <value>786, 0</value>
   </data>
   <data name="label22.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -2944,7 +3268,7 @@
     <value>label22</value>
   </data>
   <data name="&gt;&gt;label22.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label22.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2959,10 +3283,13 @@
     <value>NoControl</value>
   </data>
   <data name="label23.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 110</value>
+    <value>4, 169</value>
+  </data>
+  <data name="label23.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label23.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 13</value>
+    <value>132, 20</value>
   </data>
   <data name="label23.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -2974,7 +3301,7 @@
     <value>label23</value>
   </data>
   <data name="&gt;&gt;label23.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label23.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -2989,10 +3316,13 @@
     <value>NoControl</value>
   </data>
   <data name="TargetITOPOD.Location" type="System.Drawing.Point, System.Drawing">
-    <value>357, 86</value>
+    <value>536, 132</value>
+  </data>
+  <data name="TargetITOPOD.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="TargetITOPOD.Size" type="System.Drawing.Size, System.Drawing">
-    <value>67, 17</value>
+    <value>95, 24</value>
   </data>
   <data name="TargetITOPOD.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -3004,7 +3334,7 @@
     <value>TargetITOPOD</value>
   </data>
   <data name="&gt;&gt;TargetITOPOD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TargetITOPOD.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3019,10 +3349,13 @@
     <value>NoControl</value>
   </data>
   <data name="OptimizeITOPOD.Location" type="System.Drawing.Point, System.Drawing">
-    <value>380, 167</value>
+    <value>570, 257</value>
+  </data>
+  <data name="OptimizeITOPOD.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="OptimizeITOPOD.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 17</value>
+    <value>201, 24</value>
   </data>
   <data name="OptimizeITOPOD.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -3034,7 +3367,7 @@
     <value>OptimizeITOPOD</value>
   </data>
   <data name="&gt;&gt;OptimizeITOPOD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;OptimizeITOPOD.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3049,10 +3382,13 @@
     <value>NoControl</value>
   </data>
   <data name="BeastMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>291, 30</value>
+    <value>436, 46</value>
+  </data>
+  <data name="BeastMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="BeastMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 17</value>
+    <value>121, 24</value>
   </data>
   <data name="BeastMode.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -3064,7 +3400,7 @@
     <value>BeastMode</value>
   </data>
   <data name="&gt;&gt;BeastMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BeastMode.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3079,10 +3415,13 @@
     <value>NoControl</value>
   </data>
   <data name="AllowFallthrough.Location" type="System.Drawing.Point, System.Drawing">
-    <value>245, 85</value>
+    <value>368, 131</value>
+  </data>
+  <data name="AllowFallthrough.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="AllowFallthrough.Size" type="System.Drawing.Size, System.Drawing">
-    <value>106, 17</value>
+    <value>156, 24</value>
   </data>
   <data name="AllowFallthrough.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -3094,7 +3433,7 @@
     <value>AllowFallthrough</value>
   </data>
   <data name="&gt;&gt;AllowFallthrough.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AllowFallthrough.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3109,10 +3448,13 @@
     <value>NoControl</value>
   </data>
   <data name="RecoverHealth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 30</value>
+    <value>162, 46</value>
+  </data>
+  <data name="RecoverHealth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="RecoverHealth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 17</value>
+    <value>120, 24</value>
   </data>
   <data name="RecoverHealth.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -3124,7 +3466,7 @@
     <value>RecoverHealth</value>
   </data>
   <data name="&gt;&gt;RecoverHealth.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;RecoverHealth.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3139,10 +3481,13 @@
     <value>NoControl</value>
   </data>
   <data name="FastCombat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>199, 30</value>
+    <value>298, 46</value>
+  </data>
+  <data name="FastCombat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="FastCombat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 17</value>
+    <value>127, 24</value>
   </data>
   <data name="FastCombat.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -3154,7 +3499,7 @@
     <value>FastCombat</value>
   </data>
   <data name="&gt;&gt;FastCombat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;FastCombat.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3169,10 +3514,13 @@
     <value>NoControl</value>
   </data>
   <data name="PrecastBuffs.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 30</value>
+    <value>9, 46</value>
+  </data>
+  <data name="PrecastBuffs.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="PrecastBuffs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 17</value>
+    <value>131, 24</value>
   </data>
   <data name="PrecastBuffs.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -3184,7 +3532,7 @@
     <value>PrecastBuffs</value>
   </data>
   <data name="&gt;&gt;PrecastBuffs.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;PrecastBuffs.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3199,10 +3547,13 @@
     <value>NoControl</value>
   </data>
   <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 86</value>
+    <value>4, 132</value>
+  </data>
+  <data name="label6.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 13</value>
+    <value>96, 20</value>
   </data>
   <data name="label6.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -3214,7 +3565,7 @@
     <value>label6</value>
   </data>
   <data name="&gt;&gt;label6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label6.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3229,10 +3580,13 @@
     <value>Manual</value>
   </data>
   <data name="CombatTargetZone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 82</value>
+    <value>162, 126</value>
+  </data>
+  <data name="CombatTargetZone.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="CombatTargetZone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+    <value>180, 28</value>
   </data>
   <data name="CombatTargetZone.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -3241,7 +3595,7 @@
     <value>CombatTargetZone</value>
   </data>
   <data name="&gt;&gt;CombatTargetZone.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CombatTargetZone.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3256,10 +3610,13 @@
     <value>NoControl</value>
   </data>
   <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 53</value>
+    <value>4, 82</value>
+  </data>
+  <data name="label4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 13</value>
+    <value>109, 20</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -3271,7 +3628,7 @@
     <value>label4</value>
   </data>
   <data name="&gt;&gt;label4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label4.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3286,10 +3643,13 @@
     <value>Manual</value>
   </data>
   <data name="CombatMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 50</value>
+    <value>162, 77</value>
+  </data>
+  <data name="CombatMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="CombatMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+    <value>180, 28</value>
   </data>
   <data name="CombatMode.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -3298,7 +3658,7 @@
     <value>CombatMode</value>
   </data>
   <data name="&gt;&gt;CombatMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CombatMode.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3313,10 +3673,13 @@
     <value>NoControl</value>
   </data>
   <data name="BossesOnly.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 7</value>
+    <value>162, 11</value>
+  </data>
+  <data name="BossesOnly.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="BossesOnly.Size" type="System.Drawing.Size, System.Drawing">
-    <value>84, 17</value>
+    <value>123, 24</value>
   </data>
   <data name="BossesOnly.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -3328,7 +3691,7 @@
     <value>BossesOnly</value>
   </data>
   <data name="&gt;&gt;BossesOnly.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;BossesOnly.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3343,10 +3706,13 @@
     <value>NoControl</value>
   </data>
   <data name="CombatActive.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 7</value>
+    <value>9, 11</value>
+  </data>
+  <data name="CombatActive.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="CombatActive.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 17</value>
+    <value>154, 24</value>
   </data>
   <data name="CombatActive.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -3358,7 +3724,7 @@
     <value>CombatActive</value>
   </data>
   <data name="&gt;&gt;CombatActive.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CombatActive.Parent" xml:space="preserve">
     <value>tabPage6</value>
@@ -3367,13 +3733,16 @@
     <value>30</value>
   </data>
   <data name="tabPage6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="tabPage6.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage6.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>590, 334</value>
+    <value>889, 521</value>
   </data>
   <data name="tabPage6.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -3385,7 +3754,7 @@
     <value>tabPage6</value>
   </data>
   <data name="&gt;&gt;tabPage6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage6.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -3400,10 +3769,13 @@
     <value>NoControl</value>
   </data>
   <data name="CBlockMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>409, 33</value>
+    <value>614, 51</value>
+  </data>
+  <data name="CBlockMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="CBlockMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>90, 17</value>
+    <value>129, 24</value>
   </data>
   <data name="CBlockMode.TabIndex" type="System.Int32, mscorlib">
     <value>34</value>
@@ -3415,7 +3787,7 @@
     <value>CBlockMode</value>
   </data>
   <data name="&gt;&gt;CBlockMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;CBlockMode.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3427,10 +3799,13 @@
     <value>NoControl</value>
   </data>
   <data name="ResetTitanStatus.Location" type="System.Drawing.Point, System.Drawing">
-    <value>444, 290</value>
+    <value>666, 446</value>
+  </data>
+  <data name="ResetTitanStatus.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ResetTitanStatus.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 23</value>
+    <value>176, 35</value>
   </data>
   <data name="ResetTitanStatus.TabIndex" type="System.Int32, mscorlib">
     <value>33</value>
@@ -3442,7 +3817,7 @@
     <value>ResetTitanStatus</value>
   </data>
   <data name="&gt;&gt;ResetTitanStatus.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ResetTitanStatus.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3460,10 +3835,13 @@
     <value>NoControl</value>
   </data>
   <data name="label21.Location" type="System.Drawing.Point, System.Drawing">
-    <value>350, 70</value>
+    <value>525, 108</value>
+  </data>
+  <data name="label21.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label21.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 16</value>
+    <value>176, 25</value>
   </data>
   <data name="label21.TabIndex" type="System.Int32, mscorlib">
     <value>32</value>
@@ -3475,7 +3853,7 @@
     <value>label21</value>
   </data>
   <data name="&gt;&gt;label21.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label21.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3490,10 +3868,13 @@
     <value>203</value>
   </data>
   <data name="TitanGoldTargets.Location" type="System.Drawing.Point, System.Drawing">
-    <value>353, 98</value>
+    <value>530, 151</value>
+  </data>
+  <data name="TitanGoldTargets.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="TitanGoldTargets.Size" type="System.Drawing.Size, System.Drawing">
-    <value>208, 186</value>
+    <value>310, 284</value>
   </data>
   <data name="TitanGoldTargets.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -3502,7 +3883,7 @@
     <value>TitanGoldTargets</value>
   </data>
   <data name="&gt;&gt;TitanGoldTargets.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;TitanGoldTargets.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3514,10 +3895,13 @@
     <value>NoControl</value>
   </data>
   <data name="SaveResnipeButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>328, 30</value>
+    <value>492, 46</value>
+  </data>
+  <data name="SaveResnipeButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="SaveResnipeButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>112, 31</value>
   </data>
   <data name="SaveResnipeButton.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -3529,7 +3913,7 @@
     <value>SaveResnipeButton</value>
   </data>
   <data name="&gt;&gt;SaveResnipeButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;SaveResnipeButton.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3538,10 +3922,13 @@
     <value>4</value>
   </data>
   <data name="ResnipeInput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>202, 30</value>
+    <value>303, 46</value>
+  </data>
+  <data name="ResnipeInput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ResnipeInput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
+    <value>180, 26</value>
   </data>
   <data name="ResnipeInput.TabIndex" type="System.Int32, mscorlib">
     <value>29</value>
@@ -3550,7 +3937,7 @@
     <value>ResnipeInput</value>
   </data>
   <data name="&gt;&gt;ResnipeInput.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ResnipeInput.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3565,10 +3952,13 @@
     <value>NoControl</value>
   </data>
   <data name="label10.Location" type="System.Drawing.Point, System.Drawing">
-    <value>124, 34</value>
+    <value>186, 52</value>
+  </data>
+  <data name="label10.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 13</value>
+    <value>106, 20</value>
   </data>
   <data name="label10.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
@@ -3580,7 +3970,7 @@
     <value>label10</value>
   </data>
   <data name="&gt;&gt;label10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label10.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3595,10 +3985,13 @@
     <value>NoControl</value>
   </data>
   <data name="ManageGoldLoadouts.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 7</value>
+    <value>16, 11</value>
+  </data>
+  <data name="ManageGoldLoadouts.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ManageGoldLoadouts.Size" type="System.Drawing.Size, System.Drawing">
-    <value>149, 17</value>
+    <value>221, 24</value>
   </data>
   <data name="ManageGoldLoadouts.TabIndex" type="System.Int32, mscorlib">
     <value>26</value>
@@ -3610,7 +4003,7 @@
     <value>ManageGoldLoadouts</value>
   </data>
   <data name="&gt;&gt;ManageGoldLoadouts.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageGoldLoadouts.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3625,10 +4018,13 @@
     <value>NoControl</value>
   </data>
   <data name="UseGoldLoadout.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 33</value>
+    <value>18, 51</value>
+  </data>
+  <data name="UseGoldLoadout.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="UseGoldLoadout.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 17</value>
+    <value>139, 24</value>
   </data>
   <data name="UseGoldLoadout.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -3640,7 +4036,7 @@
     <value>UseGoldLoadout</value>
   </data>
   <data name="&gt;&gt;UseGoldLoadout.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;UseGoldLoadout.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3658,10 +4054,13 @@
     <value>NoControl</value>
   </data>
   <data name="label11.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 70</value>
+    <value>6, 108</value>
+  </data>
+  <data name="label11.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label11.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 16</value>
+    <value>83, 25</value>
   </data>
   <data name="label11.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -3673,7 +4072,7 @@
     <value>label11</value>
   </data>
   <data name="&gt;&gt;label11.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label11.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3688,10 +4087,13 @@
     <value>NoControl</value>
   </data>
   <data name="GoldLoadoutRemove.Location" type="System.Drawing.Point, System.Drawing">
-    <value>249, 161</value>
+    <value>374, 248</value>
+  </data>
+  <data name="GoldLoadoutRemove.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="GoldLoadoutRemove.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 23</value>
+    <value>171, 46</value>
   </data>
   <data name="GoldLoadoutRemove.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -3703,7 +4105,7 @@
     <value>GoldLoadoutRemove</value>
   </data>
   <data name="&gt;&gt;GoldLoadoutRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GoldLoadoutRemove.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3712,10 +4114,13 @@
     <value>10</value>
   </data>
   <data name="GoldItemBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 264</value>
+    <value>10, 406</value>
+  </data>
+  <data name="GoldItemBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="GoldItemBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>222, 20</value>
+    <value>333, 26</value>
   </data>
   <data name="GoldItemBox.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -3724,7 +4129,7 @@
     <value>GoldItemBox</value>
   </data>
   <data name="&gt;&gt;GoldItemBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GoldItemBox.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3739,10 +4144,13 @@
     <value>NoControl</value>
   </data>
   <data name="GoldItemLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 287</value>
+    <value>9, 442</value>
+  </data>
+  <data name="GoldItemLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="GoldItemLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 13</value>
+    <value>20, 20</value>
   </data>
   <data name="GoldItemLabel.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -3754,7 +4162,7 @@
     <value>GoldItemLabel</value>
   </data>
   <data name="&gt;&gt;GoldItemLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GoldItemLabel.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3766,10 +4174,13 @@
     <value>NoControl</value>
   </data>
   <data name="GoldLoadoutAdd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>249, 264</value>
+    <value>374, 406</value>
+  </data>
+  <data name="GoldLoadoutAdd.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="GoldLoadoutAdd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>112, 31</value>
   </data>
   <data name="GoldLoadoutAdd.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -3781,13 +4192,16 @@
     <value>GoldLoadoutAdd</value>
   </data>
   <data name="&gt;&gt;GoldLoadoutAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GoldLoadoutAdd.Parent" xml:space="preserve">
     <value>tabPage7</value>
   </data>
   <data name="&gt;&gt;GoldLoadoutAdd.ZOrder" xml:space="preserve">
     <value>13</value>
+  </data>
+  <data name="GoldLoadout.ItemHeight" type="System.Int32, mscorlib">
+    <value>20</value>
   </data>
   <data name="GoldLoadout.Items" xml:space="preserve">
     <value>test</value>
@@ -3796,10 +4210,13 @@
     <value>test2</value>
   </data>
   <data name="GoldLoadout.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 98</value>
+    <value>9, 151</value>
+  </data>
+  <data name="GoldLoadout.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="GoldLoadout.Size" type="System.Drawing.Size, System.Drawing">
-    <value>223, 160</value>
+    <value>332, 244</value>
   </data>
   <data name="GoldLoadout.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -3808,7 +4225,7 @@
     <value>GoldLoadout</value>
   </data>
   <data name="&gt;&gt;GoldLoadout.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;GoldLoadout.Parent" xml:space="preserve">
     <value>tabPage7</value>
@@ -3817,13 +4234,16 @@
     <value>14</value>
   </data>
   <data name="tabPage7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="tabPage7.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage7.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>590, 334</value>
+    <value>889, 521</value>
   </data>
   <data name="tabPage7.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -3835,12 +4255,234 @@
     <value>tabPage7</value>
   </data>
   <data name="&gt;&gt;tabPage7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage7.Parent" xml:space="preserve">
     <value>tabControl1</value>
   </data>
   <data name="&gt;&gt;tabPage7.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="QuestSwap.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="QuestSwap.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="QuestSwap.Location" type="System.Drawing.Point, System.Drawing">
+    <value>423, 82</value>
+  </data>
+  <data name="QuestSwap.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="QuestSwap.Size" type="System.Drawing.Size, System.Drawing">
+    <value>272, 24</value>
+  </data>
+  <data name="QuestSwap.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="QuestSwap.Text" xml:space="preserve">
+    <value>Swap Loadout for Manual Quests</value>
+  </data>
+  <data name="&gt;&gt;QuestSwap.Name" xml:space="preserve">
+    <value>QuestSwap</value>
+  </data>
+  <data name="&gt;&gt;QuestSwap.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;QuestSwap.Parent" xml:space="preserve">
+    <value>tabPage8</value>
+  </data>
+  <data name="&gt;&gt;QuestSwap.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 9.75pt</value>
+  </data>
+  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>8, 260</value>
+  </data>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 25</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Loadout</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>tabPage8</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="questRemoveButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="questRemoveButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="questRemoveButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>353, 301</value>
+  </data>
+  <data name="questRemoveButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="questRemoveButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>171, 46</value>
+  </data>
+  <data name="questRemoveButton.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="questRemoveButton.Text" xml:space="preserve">
+    <value>Remove Item</value>
+  </data>
+  <data name="&gt;&gt;questRemoveButton.Name" xml:space="preserve">
+    <value>questRemoveButton</value>
+  </data>
+  <data name="&gt;&gt;questRemoveButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;questRemoveButton.Parent" xml:space="preserve">
+    <value>tabPage8</value>
+  </data>
+  <data name="&gt;&gt;questRemoveButton.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="questLoadoutItem.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 430</value>
+  </data>
+  <data name="questLoadoutItem.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="questLoadoutItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>308, 26</value>
+  </data>
+  <data name="questLoadoutItem.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;questLoadoutItem.Name" xml:space="preserve">
+    <value>questLoadoutItem</value>
+  </data>
+  <data name="&gt;&gt;questLoadoutItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;questLoadoutItem.Parent" xml:space="preserve">
+    <value>tabPage8</value>
+  </data>
+  <data name="&gt;&gt;questLoadoutItem.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="questItemLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="questItemLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="questItemLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 471</value>
+  </data>
+  <data name="questItemLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
+  </data>
+  <data name="questItemLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>20, 20</value>
+  </data>
+  <data name="questItemLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="questItemLabel.Text" xml:space="preserve">
+    <value>A</value>
+  </data>
+  <data name="&gt;&gt;questItemLabel.Name" xml:space="preserve">
+    <value>questItemLabel</value>
+  </data>
+  <data name="&gt;&gt;questItemLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;questItemLabel.Parent" xml:space="preserve">
+    <value>tabPage8</value>
+  </data>
+  <data name="&gt;&gt;questItemLabel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="questAddButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="questAddButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>353, 430</value>
+  </data>
+  <data name="questAddButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="questAddButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>112, 31</value>
+  </data>
+  <data name="questAddButton.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="questAddButton.Text" xml:space="preserve">
+    <value>Add Item</value>
+  </data>
+  <data name="&gt;&gt;questAddButton.Name" xml:space="preserve">
+    <value>questAddButton</value>
+  </data>
+  <data name="&gt;&gt;questAddButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;questAddButton.Parent" xml:space="preserve">
+    <value>tabPage8</value>
+  </data>
+  <data name="&gt;&gt;questAddButton.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="questLoadoutBox.ItemHeight" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="questLoadoutBox.Items" xml:space="preserve">
+    <value>test</value>
+  </data>
+  <data name="questLoadoutBox.Items1" xml:space="preserve">
+    <value>test2</value>
+  </data>
+  <data name="questLoadoutBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>13, 303</value>
+  </data>
+  <data name="questLoadoutBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="questLoadoutBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>307, 104</value>
+  </data>
+  <data name="questLoadoutBox.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;questLoadoutBox.Name" xml:space="preserve">
+    <value>questLoadoutBox</value>
+  </data>
+  <data name="&gt;&gt;questLoadoutBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;questLoadoutBox.Parent" xml:space="preserve">
+    <value>tabPage8</value>
+  </data>
+  <data name="&gt;&gt;questLoadoutBox.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
   <data name="ButterMinors.AutoSize" type="System.Boolean, mscorlib">
@@ -3850,10 +4492,13 @@
     <value>NoControl</value>
   </data>
   <data name="ButterMinors.Location" type="System.Drawing.Point, System.Drawing">
-    <value>140, 54</value>
+    <value>210, 83</value>
+  </data>
+  <data name="ButterMinors.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ButterMinors.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 17</value>
+    <value>185, 24</value>
   </data>
   <data name="ButterMinors.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -3865,13 +4510,13 @@
     <value>ButterMinors</value>
   </data>
   <data name="&gt;&gt;ButterMinors.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ButterMinors.Parent" xml:space="preserve">
     <value>tabPage8</value>
   </data>
   <data name="&gt;&gt;ButterMinors.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>7</value>
   </data>
   <data name="ButterMajors.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3880,10 +4525,13 @@
     <value>NoControl</value>
   </data>
   <data name="ButterMajors.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 54</value>
+    <value>10, 83</value>
+  </data>
+  <data name="ButterMajors.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ButterMajors.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 17</value>
+    <value>185, 24</value>
   </data>
   <data name="ButterMajors.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -3895,13 +4543,13 @@
     <value>ButterMajors</value>
   </data>
   <data name="&gt;&gt;ButterMajors.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ButterMajors.Parent" xml:space="preserve">
     <value>tabPage8</value>
   </data>
   <data name="&gt;&gt;ButterMajors.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>8</value>
   </data>
   <data name="ManualMinor.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3910,10 +4558,13 @@
     <value>NoControl</value>
   </data>
   <data name="ManualMinor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>271, 31</value>
+    <value>406, 48</value>
+  </data>
+  <data name="ManualMinor.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ManualMinor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 17</value>
+    <value>138, 24</value>
   </data>
   <data name="ManualMinor.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -3925,13 +4576,13 @@
     <value>ManualMinor</value>
   </data>
   <data name="&gt;&gt;ManualMinor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManualMinor.Parent" xml:space="preserve">
     <value>tabPage8</value>
   </data>
   <data name="&gt;&gt;ManualMinor.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>9</value>
   </data>
   <data name="QuestFastCombat.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3940,10 +4591,13 @@
     <value>NoControl</value>
   </data>
   <data name="QuestFastCombat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>328, 134</value>
+    <value>492, 206</value>
+  </data>
+  <data name="QuestFastCombat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="QuestFastCombat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 17</value>
+    <value>127, 24</value>
   </data>
   <data name="QuestFastCombat.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -3955,13 +4609,13 @@
     <value>QuestFastCombat</value>
   </data>
   <data name="&gt;&gt;QuestFastCombat.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;QuestFastCombat.Parent" xml:space="preserve">
     <value>tabPage8</value>
   </data>
   <data name="&gt;&gt;QuestFastCombat.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>10</value>
   </data>
   <data name="AbandonMinors.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3970,10 +4624,13 @@
     <value>NoControl</value>
   </data>
   <data name="AbandonMinors.Location" type="System.Drawing.Point, System.Drawing">
-    <value>130, 31</value>
+    <value>195, 48</value>
+  </data>
+  <data name="AbandonMinors.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="AbandonMinors.Size" type="System.Drawing.Size, System.Drawing">
-    <value>134, 17</value>
+    <value>198, 24</value>
   </data>
   <data name="AbandonMinors.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -3985,19 +4642,22 @@
     <value>AbandonMinors</value>
   </data>
   <data name="&gt;&gt;AbandonMinors.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AbandonMinors.Parent" xml:space="preserve">
     <value>tabPage8</value>
   </data>
   <data name="&gt;&gt;AbandonMinors.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>11</value>
   </data>
   <data name="AbandonMinorThreshold.Location" type="System.Drawing.Point, System.Drawing">
-    <value>201, 99</value>
+    <value>302, 152</value>
+  </data>
+  <data name="AbandonMinorThreshold.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="AbandonMinorThreshold.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 20</value>
+    <value>180, 26</value>
   </data>
   <data name="AbandonMinorThreshold.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -4006,13 +4666,13 @@
     <value>AbandonMinorThreshold</value>
   </data>
   <data name="&gt;&gt;AbandonMinorThreshold.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AbandonMinorThreshold.Parent" xml:space="preserve">
     <value>tabPage8</value>
   </data>
   <data name="&gt;&gt;AbandonMinorThreshold.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>12</value>
   </data>
   <data name="label13.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -4021,10 +4681,13 @@
     <value>NoControl</value>
   </data>
   <data name="label13.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 101</value>
+    <value>9, 155</value>
+  </data>
+  <data name="label13.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label13.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 13</value>
+    <value>266, 20</value>
   </data>
   <data name="label13.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -4036,13 +4699,13 @@
     <value>label13</value>
   </data>
   <data name="&gt;&gt;label13.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label13.Parent" xml:space="preserve">
     <value>tabPage8</value>
   </data>
   <data name="&gt;&gt;label13.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>13</value>
   </data>
   <data name="label12.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -4051,10 +4714,13 @@
     <value>NoControl</value>
   </data>
   <data name="label12.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 134</value>
+    <value>9, 206</value>
+  </data>
+  <data name="label12.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label12.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 13</value>
+    <value>109, 20</value>
   </data>
   <data name="label12.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -4066,13 +4732,13 @@
     <value>label12</value>
   </data>
   <data name="&gt;&gt;label12.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label12.Parent" xml:space="preserve">
     <value>tabPage8</value>
   </data>
   <data name="&gt;&gt;label12.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>14</value>
   </data>
   <data name="QuestCombatMode.Items" xml:space="preserve">
     <value>Idle</value>
@@ -4081,10 +4747,13 @@
     <value>Manual</value>
   </data>
   <data name="QuestCombatMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>201, 132</value>
+    <value>302, 203</value>
+  </data>
+  <data name="QuestCombatMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="QuestCombatMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+    <value>180, 28</value>
   </data>
   <data name="QuestCombatMode.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -4093,13 +4762,13 @@
     <value>QuestCombatMode</value>
   </data>
   <data name="&gt;&gt;QuestCombatMode.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;QuestCombatMode.Parent" xml:space="preserve">
     <value>tabPage8</value>
   </data>
   <data name="&gt;&gt;QuestCombatMode.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>15</value>
   </data>
   <data name="AllowMajor.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -4108,10 +4777,13 @@
     <value>NoControl</value>
   </data>
   <data name="AllowMajor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 31</value>
+    <value>10, 48</value>
+  </data>
+  <data name="AllowMajor.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="AllowMajor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>116, 17</value>
+    <value>170, 24</value>
   </data>
   <data name="AllowMajor.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -4123,13 +4795,13 @@
     <value>AllowMajor</value>
   </data>
   <data name="&gt;&gt;AllowMajor.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AllowMajor.Parent" xml:space="preserve">
     <value>tabPage8</value>
   </data>
   <data name="&gt;&gt;AllowMajor.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>16</value>
   </data>
   <data name="ManageQuests.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -4138,10 +4810,13 @@
     <value>NoControl</value>
   </data>
   <data name="ManageQuests.Location" type="System.Drawing.Point, System.Drawing">
-    <value>7, 7</value>
+    <value>10, 11</value>
+  </data>
+  <data name="ManageQuests.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ManageQuests.Size" type="System.Drawing.Size, System.Drawing">
-    <value>79, 17</value>
+    <value>116, 24</value>
   </data>
   <data name="ManageQuests.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -4153,22 +4828,25 @@
     <value>ManageQuests</value>
   </data>
   <data name="&gt;&gt;ManageQuests.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;ManageQuests.Parent" xml:space="preserve">
     <value>tabPage8</value>
   </data>
   <data name="&gt;&gt;ManageQuests.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>17</value>
   </data>
   <data name="tabPage8.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="tabPage8.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage8.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>590, 334</value>
+    <value>889, 521</value>
   </data>
   <data name="tabPage8.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -4180,7 +4858,7 @@
     <value>tabPage8</value>
   </data>
   <data name="&gt;&gt;tabPage8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage8.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -4192,10 +4870,13 @@
     <value>True</value>
   </data>
   <data name="WishSortOrder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 6</value>
+    <value>12, 9</value>
+  </data>
+  <data name="WishSortOrder.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="WishSortOrder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 17</value>
+    <value>263, 24</value>
   </data>
   <data name="WishSortOrder.TabIndex" type="System.Int32, mscorlib">
     <value>37</value>
@@ -4207,7 +4888,7 @@
     <value>WishSortOrder</value>
   </data>
   <data name="&gt;&gt;WishSortOrder.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;WishSortOrder.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4219,10 +4900,13 @@
     <value>True</value>
   </data>
   <data name="WishSortPriorities.Location" type="System.Drawing.Point, System.Drawing">
-    <value>369, 232</value>
+    <value>554, 357</value>
+  </data>
+  <data name="WishSortPriorities.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="WishSortPriorities.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 17</value>
+    <value>172, 24</value>
   </data>
   <data name="WishSortPriorities.TabIndex" type="System.Int32, mscorlib">
     <value>36</value>
@@ -4234,7 +4918,7 @@
     <value>WishSortPriorities</value>
   </data>
   <data name="&gt;&gt;WishSortPriorities.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;WishSortPriorities.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4249,10 +4933,13 @@
     <value>NoControl</value>
   </data>
   <data name="WishDownButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>313, 157</value>
+    <value>470, 242</value>
+  </data>
+  <data name="WishDownButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="WishDownButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 23</value>
+    <value>39, 46</value>
   </data>
   <data name="WishDownButton.TabIndex" type="System.Int32, mscorlib">
     <value>35</value>
@@ -4264,7 +4951,7 @@
     <value>WishDownButton</value>
   </data>
   <data name="&gt;&gt;WishDownButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;WishDownButton.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4279,10 +4966,13 @@
     <value>NoControl</value>
   </data>
   <data name="WishUpButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>313, 99</value>
+    <value>470, 152</value>
+  </data>
+  <data name="WishUpButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="WishUpButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>23, 23</value>
+    <value>39, 46</value>
   </data>
   <data name="WishUpButton.TabIndex" type="System.Int32, mscorlib">
     <value>34</value>
@@ -4294,7 +4984,7 @@
     <value>WishUpButton</value>
   </data>
   <data name="&gt;&gt;WishUpButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;WishUpButton.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4309,10 +4999,13 @@
     <value>NoControl</value>
   </data>
   <data name="RemoveWishButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>283, 128</value>
+    <value>424, 197</value>
+  </data>
+  <data name="RemoveWishButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="RemoveWishButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>84, 23</value>
+    <value>176, 46</value>
   </data>
   <data name="RemoveWishButton.TabIndex" type="System.Int32, mscorlib">
     <value>33</value>
@@ -4324,7 +5017,7 @@
     <value>RemoveWishButton</value>
   </data>
   <data name="&gt;&gt;RemoveWishButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;RemoveWishButton.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4342,10 +5035,13 @@
     <value>NoControl</value>
   </data>
   <data name="label19.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 35</value>
+    <value>9, 54</value>
+  </data>
+  <data name="label19.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label19.Size" type="System.Drawing.Size, System.Drawing">
-    <value>97, 16</value>
+    <value>142, 25</value>
   </data>
   <data name="label19.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -4357,7 +5053,7 @@
     <value>label19</value>
   </data>
   <data name="&gt;&gt;label19.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label19.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4366,10 +5062,13 @@
     <value>5</value>
   </data>
   <data name="WishAddInput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 229</value>
+    <value>14, 352</value>
+  </data>
+  <data name="WishAddInput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="WishAddInput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>246, 20</value>
+    <value>369, 26</value>
   </data>
   <data name="WishAddInput.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
@@ -4378,7 +5077,7 @@
     <value>WishAddInput</value>
   </data>
   <data name="&gt;&gt;WishAddInput.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;WishAddInput.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4393,10 +5092,13 @@
     <value>NoControl</value>
   </data>
   <data name="AddWishLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 252</value>
+    <value>12, 388</value>
+  </data>
+  <data name="AddWishLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="AddWishLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 13</value>
+    <value>20, 20</value>
   </data>
   <data name="AddWishLabel.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -4408,7 +5110,7 @@
     <value>AddWishLabel</value>
   </data>
   <data name="&gt;&gt;AddWishLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AddWishLabel.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4420,10 +5122,13 @@
     <value>NoControl</value>
   </data>
   <data name="AddWishButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>288, 229</value>
+    <value>432, 352</value>
+  </data>
+  <data name="AddWishButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="AddWishButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>112, 31</value>
   </data>
   <data name="AddWishButton.TabIndex" type="System.Int32, mscorlib">
     <value>26</value>
@@ -4435,13 +5140,16 @@
     <value>AddWishButton</value>
   </data>
   <data name="&gt;&gt;AddWishButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AddWishButton.Parent" xml:space="preserve">
     <value>tabPage9</value>
   </data>
   <data name="&gt;&gt;AddWishButton.ZOrder" xml:space="preserve">
     <value>8</value>
+  </data>
+  <data name="WishPriority.ItemHeight" type="System.Int32, mscorlib">
+    <value>20</value>
   </data>
   <data name="WishPriority.Items" xml:space="preserve">
     <value>test</value>
@@ -4450,10 +5158,13 @@
     <value>test2</value>
   </data>
   <data name="WishPriority.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 63</value>
+    <value>12, 97</value>
+  </data>
+  <data name="WishPriority.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="WishPriority.Size" type="System.Drawing.Size, System.Drawing">
-    <value>247, 160</value>
+    <value>368, 244</value>
   </data>
   <data name="WishPriority.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -4462,7 +5173,7 @@
     <value>WishPriority</value>
   </data>
   <data name="&gt;&gt;WishPriority.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;WishPriority.Parent" xml:space="preserve">
     <value>tabPage9</value>
@@ -4471,13 +5182,16 @@
     <value>9</value>
   </data>
   <data name="tabPage9.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="tabPage9.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage9.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>590, 334</value>
+    <value>889, 521</value>
   </data>
   <data name="tabPage9.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -4489,7 +5203,7 @@
     <value>tabPage9</value>
   </data>
   <data name="&gt;&gt;tabPage9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage9.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -4507,10 +5221,13 @@
     <value>NoControl</value>
   </data>
   <data name="label25.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 68</value>
+    <value>9, 105</value>
+  </data>
+  <data name="label25.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label25.Size" type="System.Drawing.Size, System.Drawing">
-    <value>57, 16</value>
+    <value>83, 25</value>
   </data>
   <data name="label25.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -4522,7 +5239,7 @@
     <value>label25</value>
   </data>
   <data name="&gt;&gt;label25.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label25.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4537,10 +5254,13 @@
     <value>NoControl</value>
   </data>
   <data name="MoneyPitRemove.Location" type="System.Drawing.Point, System.Drawing">
-    <value>267, 159</value>
+    <value>400, 245</value>
+  </data>
+  <data name="MoneyPitRemove.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="MoneyPitRemove.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 23</value>
+    <value>171, 46</value>
   </data>
   <data name="MoneyPitRemove.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -4552,7 +5272,7 @@
     <value>MoneyPitRemove</value>
   </data>
   <data name="&gt;&gt;MoneyPitRemove.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MoneyPitRemove.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4561,10 +5281,13 @@
     <value>1</value>
   </data>
   <data name="MoneyPitInput.Location" type="System.Drawing.Point, System.Drawing">
-    <value>10, 263</value>
+    <value>15, 405</value>
+  </data>
+  <data name="MoneyPitInput.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="MoneyPitInput.Size" type="System.Drawing.Size, System.Drawing">
-    <value>251, 20</value>
+    <value>376, 26</value>
   </data>
   <data name="MoneyPitInput.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -4573,7 +5296,7 @@
     <value>MoneyPitInput</value>
   </data>
   <data name="&gt;&gt;MoneyPitInput.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MoneyPitInput.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4588,10 +5311,13 @@
     <value>NoControl</value>
   </data>
   <data name="MoneyPitLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 286</value>
+    <value>14, 440</value>
+  </data>
+  <data name="MoneyPitLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="MoneyPitLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 13</value>
+    <value>20, 20</value>
   </data>
   <data name="MoneyPitLabel.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -4603,7 +5329,7 @@
     <value>MoneyPitLabel</value>
   </data>
   <data name="&gt;&gt;MoneyPitLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MoneyPitLabel.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4615,10 +5341,13 @@
     <value>NoControl</value>
   </data>
   <data name="MoneyPitAdd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>267, 262</value>
+    <value>400, 403</value>
+  </data>
+  <data name="MoneyPitAdd.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="MoneyPitAdd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 20</value>
+    <value>112, 31</value>
   </data>
   <data name="MoneyPitAdd.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -4630,13 +5359,16 @@
     <value>MoneyPitAdd</value>
   </data>
   <data name="&gt;&gt;MoneyPitAdd.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MoneyPitAdd.Parent" xml:space="preserve">
     <value>tabPage10</value>
   </data>
   <data name="&gt;&gt;MoneyPitAdd.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="MoneyPitLoadout.ItemHeight" type="System.Int32, mscorlib">
+    <value>20</value>
   </data>
   <data name="MoneyPitLoadout.Items" xml:space="preserve">
     <value>test</value>
@@ -4645,10 +5377,13 @@
     <value>test2</value>
   </data>
   <data name="MoneyPitLoadout.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 96</value>
+    <value>14, 148</value>
+  </data>
+  <data name="MoneyPitLoadout.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="MoneyPitLoadout.Size" type="System.Drawing.Size, System.Drawing">
-    <value>252, 160</value>
+    <value>376, 244</value>
   </data>
   <data name="MoneyPitLoadout.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -4657,7 +5392,7 @@
     <value>MoneyPitLoadout</value>
   </data>
   <data name="&gt;&gt;MoneyPitLoadout.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ListBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MoneyPitLoadout.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4669,10 +5404,13 @@
     <value>NoControl</value>
   </data>
   <data name="MoneyPitThresholdSave.Location" type="System.Drawing.Point, System.Drawing">
-    <value>246, 41</value>
+    <value>369, 63</value>
+  </data>
+  <data name="MoneyPitThresholdSave.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="MoneyPitThresholdSave.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 20</value>
+    <value>114, 31</value>
   </data>
   <data name="MoneyPitThresholdSave.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -4684,7 +5422,7 @@
     <value>MoneyPitThresholdSave</value>
   </data>
   <data name="&gt;&gt;MoneyPitThresholdSave.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MoneyPitThresholdSave.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4693,10 +5431,13 @@
     <value>6</value>
   </data>
   <data name="MoneyPitThreshold.Location" type="System.Drawing.Point, System.Drawing">
-    <value>116, 41</value>
+    <value>174, 63</value>
+  </data>
+  <data name="MoneyPitThreshold.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="MoneyPitThreshold.Size" type="System.Drawing.Size, System.Drawing">
-    <value>124, 20</value>
+    <value>184, 26</value>
   </data>
   <data name="MoneyPitThreshold.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -4705,7 +5446,7 @@
     <value>MoneyPitThreshold</value>
   </data>
   <data name="&gt;&gt;MoneyPitThreshold.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;MoneyPitThreshold.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4720,10 +5461,13 @@
     <value>NoControl</value>
   </data>
   <data name="label7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 44</value>
+    <value>9, 68</value>
+  </data>
+  <data name="label7.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 13</value>
+    <value>152, 20</value>
   </data>
   <data name="label7.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -4735,7 +5479,7 @@
     <value>label7</value>
   </data>
   <data name="&gt;&gt;label7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label7.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4750,10 +5494,13 @@
     <value>NoControl</value>
   </data>
   <data name="AutoMoneyPit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>110, 15</value>
+    <value>165, 23</value>
+  </data>
+  <data name="AutoMoneyPit.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="AutoMoneyPit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 17</value>
+    <value>142, 24</value>
   </data>
   <data name="AutoMoneyPit.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -4765,7 +5512,7 @@
     <value>AutoMoneyPit</value>
   </data>
   <data name="&gt;&gt;AutoMoneyPit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoMoneyPit.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4777,10 +5524,13 @@
     <value>NoControl</value>
   </data>
   <data name="AutoDailySpin.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 15</value>
+    <value>9, 23</value>
+  </data>
+  <data name="AutoDailySpin.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="AutoDailySpin.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 17</value>
+    <value>147, 26</value>
   </data>
   <data name="AutoDailySpin.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -4792,7 +5542,7 @@
     <value>AutoDailySpin</value>
   </data>
   <data name="&gt;&gt;AutoDailySpin.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;AutoDailySpin.Parent" xml:space="preserve">
     <value>tabPage10</value>
@@ -4801,13 +5551,16 @@
     <value>10</value>
   </data>
   <data name="tabPage10.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="tabPage10.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage10.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabPage10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>590, 334</value>
+    <value>889, 521</value>
   </data>
   <data name="tabPage10.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -4819,7 +5572,7 @@
     <value>tabPage10</value>
   </data>
   <data name="&gt;&gt;tabPage10.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabPage10.Parent" xml:space="preserve">
     <value>tabControl1</value>
@@ -4828,10 +5581,13 @@
     <value>9</value>
   </data>
   <data name="tabControl1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 22</value>
+    <value>4, 35</value>
+  </data>
+  <data name="tabControl1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="tabControl1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>598, 360</value>
+    <value>897, 554</value>
   </data>
   <data name="tabControl1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -4840,7 +5596,7 @@
     <value>tabControl1</value>
   </data>
   <data name="&gt;&gt;tabControl1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;tabControl1.Parent" xml:space="preserve">
     <value>flowLayoutPanel1</value>
@@ -4857,8 +5613,11 @@
   <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
   <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>605, 387</value>
+    <value>908, 595</value>
   </data>
   <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -4870,13 +5629,16 @@
     <value>flowLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>Injector Settings</value>
@@ -4885,87 +5647,96 @@
     <value>moneyPitError</value>
   </data>
   <data name="&gt;&gt;moneyPitError.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;yggErrorProvider.Name" xml:space="preserve">
     <value>yggErrorProvider</value>
   </data>
   <data name="&gt;&gt;yggErrorProvider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;questErrorProvider.Name" xml:space="preserve">
+    <value>questErrorProvider</value>
+  </data>
+  <data name="&gt;&gt;questErrorProvider.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;invPrioErrorProvider.Name" xml:space="preserve">
     <value>invPrioErrorProvider</value>
   </data>
   <data name="&gt;&gt;invPrioErrorProvider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;invBlacklistErrProvider.Name" xml:space="preserve">
     <value>invBlacklistErrProvider</value>
   </data>
   <data name="&gt;&gt;invBlacklistErrProvider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;titanErrProvider.Name" xml:space="preserve">
     <value>titanErrProvider</value>
   </data>
   <data name="&gt;&gt;titanErrProvider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;goldErrorProvider.Name" xml:space="preserve">
     <value>goldErrorProvider</value>
   </data>
   <data name="&gt;&gt;goldErrorProvider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;numberErrProvider.Name" xml:space="preserve">
     <value>numberErrProvider</value>
   </data>
   <data name="&gt;&gt;numberErrProvider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;wishErrorProvider.Name" xml:space="preserve">
     <value>wishErrorProvider</value>
   </data>
   <data name="&gt;&gt;wishErrorProvider.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ErrorProvider, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;columnHeader2.Name" xml:space="preserve">
     <value>columnHeader2</value>
   </data>
   <data name="&gt;&gt;columnHeader2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;columnHeader1.Name" xml:space="preserve">
     <value>columnHeader1</value>
   </data>
   <data name="&gt;&gt;columnHeader1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>SettingsForm</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <metadata name="yggErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>146, 17</value>
+  <metadata name="yggErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>409, 17</value>
   </metadata>
-  <metadata name="invPrioErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>290, 17</value>
+  <metadata name="questErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
-  <metadata name="invBlacklistErrProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>451, 17</value>
+  <metadata name="invPrioErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>609, 17</value>
   </metadata>
-  <metadata name="titanErrProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>622, 17</value>
+  <metadata name="invBlacklistErrProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>834, 17</value>
   </metadata>
-  <metadata name="goldErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>758, 17</value>
+  <metadata name="titanErrProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1075, 17</value>
   </metadata>
-  <metadata name="numberErrProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>906, 17</value>
+  <metadata name="goldErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1264, 17</value>
   </metadata>
-  <metadata name="wishErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>1060, 17</value>
+  <metadata name="numberErrProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1470, 17</value>
+  </metadata>
+  <metadata name="wishErrorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1686, 17</value>
   </metadata>
 </root>

--- a/NGUInjector/SettingsForm.resx
+++ b/NGUInjector/SettingsForm.resx
@@ -4263,6 +4263,42 @@
   <data name="&gt;&gt;tabPage7.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 9.75pt</value>
+  </data>
+  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>5, 200</value>
+  </data>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 25</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Loadout</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>tabPage8</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="QuestSwap.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -4294,42 +4330,6 @@
     <value>tabPage8</value>
   </data>
   <data name="&gt;&gt;QuestSwap.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label1.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 9.75pt</value>
-  </data>
-  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 260</value>
-  </data>
-  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 25</value>
-  </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>Loadout</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>tabPage8</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="questRemoveButton.AutoSize" type="System.Boolean, mscorlib">
@@ -4339,7 +4339,7 @@
     <value>NoControl</value>
   </data>
   <data name="questRemoveButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>353, 301</value>
+    <value>353, 243</value>
   </data>
   <data name="questRemoveButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>
@@ -4462,13 +4462,13 @@
     <value>test2</value>
   </data>
   <data name="questLoadoutBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 303</value>
+    <value>13, 243</value>
   </data>
   <data name="questLoadoutBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>
   </data>
   <data name="questLoadoutBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>307, 104</value>
+    <value>307, 164</value>
   </data>
   <data name="questLoadoutBox.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -4591,7 +4591,7 @@
     <value>NoControl</value>
   </data>
   <data name="QuestFastCombat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>492, 206</value>
+    <value>492, 155</value>
   </data>
   <data name="QuestFastCombat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>
@@ -4651,7 +4651,7 @@
     <value>11</value>
   </data>
   <data name="AbandonMinorThreshold.Location" type="System.Drawing.Point, System.Drawing">
-    <value>302, 152</value>
+    <value>302, 117</value>
   </data>
   <data name="AbandonMinorThreshold.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>
@@ -4681,7 +4681,7 @@
     <value>NoControl</value>
   </data>
   <data name="label13.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 155</value>
+    <value>9, 120</value>
   </data>
   <data name="label13.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 0, 4, 0</value>
@@ -4714,7 +4714,7 @@
     <value>NoControl</value>
   </data>
   <data name="label12.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 206</value>
+    <value>9, 155</value>
   </data>
   <data name="label12.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 0, 4, 0</value>
@@ -4747,7 +4747,7 @@
     <value>Manual</value>
   </data>
   <data name="QuestCombatMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>302, 203</value>
+    <value>302, 152</value>
   </data>
   <data name="QuestCombatMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>


### PR DESCRIPTION
Add support for custom manual quest loadouts.

The UI for selecting the loadout is done as per the other loadout selectors (gold/yggdrasil etc.):

![image](https://user-images.githubusercontent.com/11801387/141303535-efc205ba-aa86-4b92-bfa5-5b471894f224.png)

There is a new checkbox called "Swap Loadout for Manual Quests". If enabled, the loadout will be swapped after starting a major quest if "Allow major quests" is enabled, and for minor quests if "Manual minors" is enabled. The loadout gets reset whenever questing manually. 